### PR TITLE
fix: improve unreachable code detection

### DIFF
--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -3,8 +3,8 @@ uncalled==0.1.8
 vulture==2.14
 flake8==7.3.0
 pylint==4.0.4
-ruff==0.14.11
+ruff==0.15.6
 dead==2.1.0
-skylos==2.5.3
+skylos==4.0.0
 deadcode==2.4.1
 pylint==4.0.4

--- a/cytoscnpy/src/analyzer/aggregation/mod.rs
+++ b/cytoscnpy/src/analyzer/aggregation/mod.rs
@@ -79,7 +79,7 @@ impl CytoScnPy {
 
         let mut taint_findings = taint::run_taint_analysis(self, files);
 
-        let mut unused_counts: FxHashMap<std::path::PathBuf, usize> = FxHashMap::default();
+        let mut unused_counts: FxHashMap<&std::path::Path, usize> = FxHashMap::default();
         let all_unused_slices: [&[Definition]; 6] = [
             &classified.unused_functions,
             &classified.unused_methods,
@@ -90,11 +90,13 @@ impl CytoScnPy {
         ];
 
         for def in all_unused_slices.into_iter().flatten() {
-            *unused_counts.entry(def.file.as_ref().clone()).or_insert(0) += 1;
+            *unused_counts
+                .entry(def.file.as_ref().as_path())
+                .or_insert(0) += 1;
         }
 
         for metric in &mut state.file_metrics {
-            if let Some(count) = unused_counts.get(&metric.file) {
+            if let Some(count) = unused_counts.get(metric.file.as_path()) {
                 metric.total_issues += count;
             }
         }
@@ -113,6 +115,10 @@ impl CytoScnPy {
         sort_taint_findings(&mut taint_findings);
 
         let taint_count = taint_findings.len();
+        let secrets_count = state.all_secrets.len();
+        let danger_count = state.all_danger.len();
+        let quality_count = state.all_quality.len();
+        let parse_errors_count = state.all_parse_errors.len();
 
         AnalysisResult {
             unused_functions: classified.unused_functions,
@@ -121,19 +127,19 @@ impl CytoScnPy {
             unused_classes: classified.unused_classes,
             unused_variables: classified.unused_variables,
             unused_parameters: classified.unused_parameters,
-            secrets: state.all_secrets.clone(),
-            danger: state.all_danger.clone(),
-            quality: state.all_quality.clone(),
+            secrets: state.all_secrets,
+            danger: state.all_danger,
+            quality: state.all_quality,
             taint_findings,
-            parse_errors: state.all_parse_errors.clone(),
+            parse_errors: state.all_parse_errors,
             clones: Vec::new(),
             analysis_summary: AnalysisSummary {
                 total_files,
-                secrets_count: state.all_secrets.len(),
-                danger_count: state.all_danger.len(),
-                quality_count: state.all_quality.len(),
+                secrets_count,
+                danger_count,
+                quality_count,
                 taint_count,
-                parse_errors_count: state.all_parse_errors.len(),
+                parse_errors_count,
                 total_lines_analyzed: self.total_lines_analyzed,
                 total_definitions,
                 average_complexity: if state.files_with_quality_metrics > 0 {

--- a/cytoscnpy/src/analyzer/aggregation/state.rs
+++ b/cytoscnpy/src/analyzer/aggregation/state.rs
@@ -156,13 +156,12 @@ impl AggregationState {
             .filter_map(|(name, count)| if *count > 0 { Some(name.clone()) } else { None })
             .collect();
 
-        let mut changed = true;
-        while changed {
-            changed = false;
-            for (import_symbol, source_symbol) in &self.all_import_bindings {
-                if used_symbols.contains(import_symbol) && !used_symbols.contains(source_symbol) {
-                    used_symbols.insert(source_symbol.clone());
-                    changed = true;
+        let mut worklist: Vec<String> = used_symbols.iter().cloned().collect();
+        while let Some(symbol) = worklist.pop() {
+            if let Some(source_symbol) = self.all_import_bindings.get(&symbol) {
+                let source_symbol = source_symbol.clone();
+                if used_symbols.insert(source_symbol.clone()) {
+                    worklist.push(source_symbol);
                 }
             }
         }

--- a/cytoscnpy/src/analyzer/single_file/parsed_module.rs
+++ b/cytoscnpy/src/analyzer/single_file/parsed_module.rs
@@ -57,20 +57,18 @@ pub(super) fn analyze_parsed_module(
     }
 
     for call_name in &entry_point_calls {
-        output.visitor.add_ref(call_name.clone());
+        output.visitor.add_ref(call_name);
         if !ctx.module_name.is_empty() {
-            output
-                .visitor
-                .add_ref(format!("{}.{}", ctx.module_name, call_name));
+            let qualified = format!("{}.{}", ctx.module_name, call_name);
+            output.visitor.add_ref(&qualified);
         }
     }
 
     for framework_ref in &output.framework_visitor.framework_references {
-        output.visitor.add_ref(framework_ref.clone());
+        output.visitor.add_ref(framework_ref);
         if !ctx.module_name.is_empty() {
-            output
-                .visitor
-                .add_ref(format!("{}.{}", ctx.module_name, framework_ref));
+            let qualified = format!("{}.{}", ctx.module_name, framework_ref);
+            output.visitor.add_ref(&qualified);
         }
     }
 
@@ -90,14 +88,15 @@ pub(super) fn analyze_parsed_module(
         *output.visitor.references.entry(full_name).or_insert(0) += count;
     }
 
-    for export_name in output.visitor.exports.clone() {
-        output.visitor.add_ref(export_name.clone());
+    let exports = std::mem::take(&mut output.visitor.exports);
+    for export_name in &exports {
+        output.visitor.add_ref(export_name);
         if !ctx.module_name.is_empty() {
-            output
-                .visitor
-                .add_ref(format!("{}.{}", ctx.module_name, export_name));
+            let qualified = format!("{}.{}", ctx.module_name, export_name);
+            output.visitor.add_ref(&qualified);
         }
     }
+    output.visitor.exports = exports;
 
     CytoScnPy::mark_dynamic_import_references(
         &output.visitor.dynamic_scopes,

--- a/cytoscnpy/src/analyzer/single_file/reference_sync.rs
+++ b/cytoscnpy/src/analyzer/single_file/reference_sync.rs
@@ -17,7 +17,7 @@ impl CytoScnPy {
         }
 
         for def in definitions {
-            if def.def_type == "import" {
+            if def.def_type == DefinitionType::Import {
                 *ref_counts.entry(def.full_name.clone()).or_insert(0) += 1;
             }
         }
@@ -120,7 +120,10 @@ impl CytoScnPy {
     ) {
         let mut function_scopes: FxHashMap<String, (usize, usize)> = FxHashMap::default();
         for def in definitions.iter() {
-            if def.def_type == "function" || def.def_type == "method" {
+            if matches!(
+                def.def_type,
+                DefinitionType::Function | DefinitionType::Method
+            ) {
                 function_scopes.insert(def.full_name.clone(), (def.line, def.end_line));
             }
         }
@@ -141,8 +144,10 @@ impl CytoScnPy {
             if let Some(cfg) = Cfg::from_source(&func_source, simple_name) {
                 let flow_results = analyze_reaching_definitions(&cfg);
                 for def in definitions.iter_mut() {
-                    if (def.def_type == "variable" || def.def_type == "parameter")
-                        && def.full_name.starts_with(&func_name)
+                    if matches!(
+                        def.def_type,
+                        DefinitionType::Variable | DefinitionType::Parameter
+                    ) && def.full_name.starts_with(&func_name)
                     {
                         let relative_name = &def.full_name[func_name.len()..];
                         if let Some(var_key) = relative_name.strip_prefix('.') {

--- a/cytoscnpy/src/visitor/definition.rs
+++ b/cytoscnpy/src/visitor/definition.rs
@@ -123,7 +123,7 @@ impl<'a> CytoScnPyVisitor<'a> {
             || self.auto_called.contains(simple_name);
 
         if is_implicitly_used {
-            self.add_ref(info.name.clone());
+            self.add_ref(&info.name);
         }
 
         DefinitionFlags {

--- a/cytoscnpy/src/visitor/expr.rs
+++ b/cytoscnpy/src/visitor/expr.rs
@@ -11,20 +11,21 @@ impl<'a> CytoScnPyVisitor<'a> {
                 if scope_idx < self.scope_stack.len() - 1 {
                     self.captured_definitions.insert(qualified.clone());
                 }
-                self.add_ref(qualified);
+                self.add_ref(&qualified);
             } else if self.module_name.is_empty() {
-                self.add_ref(name.clone());
+                self.add_ref(&name);
             } else {
-                self.add_ref(format!("{}.{}", self.module_name, name));
+                let qualified = format!("{}.{}", self.module_name, name);
+                self.add_ref(&qualified);
             }
 
             if let Some(original) = self.alias_map.get(&name).cloned() {
                 if let Some(simple) = original.split('.').next_back() {
                     if simple != original {
-                        self.add_ref(simple.to_owned());
+                        self.add_ref(simple);
                     }
                 }
-                self.add_ref(original);
+                self.add_ref(&original);
             }
         }
     }
@@ -40,7 +41,7 @@ impl<'a> CytoScnPyVisitor<'a> {
                         EVAL_IDENTIFIER_RE.get_or_init(|| Regex::new(r"\b[a-zA-Z_]\w*\b").ok())
                     {
                         for m in re.find_iter(&val) {
-                            self.add_ref(m.as_str().to_owned());
+                            self.add_ref(m.as_str());
                         }
                     }
                     handled_as_literal = true;
@@ -59,11 +60,11 @@ impl<'a> CytoScnPyVisitor<'a> {
                 {
                     let attr_value = attr_str.value.to_string();
                     let attr_ref = format!("{}.{}", obj_name.id, attr_value);
-                    self.add_ref(attr_ref);
+                    self.add_ref(&attr_ref);
                     if !self.module_name.is_empty() {
                         let full_attr_ref =
                             format!("{}.{}.{}", self.module_name, obj_name.id, attr_value);
-                        self.add_ref(full_attr_ref);
+                        self.add_ref(&full_attr_ref);
                     }
                 } else {
                     let scope_id = self.get_current_scope_id();
@@ -77,11 +78,11 @@ impl<'a> CytoScnPyVisitor<'a> {
                 {
                     let attr_value = attr_str.value.to_string();
                     let attr_ref = format!("{}.{}", obj_name.id, attr_value);
-                    self.add_ref(attr_ref);
+                    self.add_ref(&attr_ref);
                     if !self.module_name.is_empty() {
                         let full_attr_ref =
                             format!("{}.{}.{}", self.module_name, obj_name.id, attr_value);
-                        self.add_ref(full_attr_ref);
+                        self.add_ref(&full_attr_ref);
                     }
                 }
             }
@@ -145,7 +146,11 @@ impl<'a> CytoScnPyVisitor<'a> {
     }
 
     pub(super) fn visit_attribute_expr(&mut self, node: &ast::ExprAttribute) {
-        self.add_ref(format!(".{}", node.attr));
+        let attr_name = node.attr.as_str();
+        let mut attr_ref = String::with_capacity(attr_name.len() + 1);
+        attr_ref.push('.');
+        attr_ref.push_str(attr_name);
+        self.add_ref(&attr_ref);
 
         if let Expr::Name(base_node) = &*node.value {
             if base_node.id.as_str() == "self" || base_node.id.as_str() == "cls" {
@@ -170,24 +175,46 @@ impl<'a> CytoScnPyVisitor<'a> {
             let base_id = name_node.id.as_str();
             let original_base_opt = self.alias_map.get(base_id).cloned();
             if let Some(original_base) = original_base_opt {
-                self.add_ref(original_base.clone());
-                let full_attr = format!("{}.{}", original_base, node.attr);
-                self.add_ref(full_attr);
+                self.add_ref(&original_base);
+                let mut full_attr =
+                    String::with_capacity(original_base.len() + 1 + attr_name.len());
+                full_attr.push_str(&original_base);
+                full_attr.push('.');
+                full_attr.push_str(attr_name);
+                self.add_ref(&full_attr);
             }
 
             if (base_id == "self" || base_id == "cls") && !self.class_stack.is_empty() {
-                let method_name = &node.attr;
-                let mut parts = Vec::new();
+                let mut total_len = attr_name.len();
                 if !self.module_name.is_empty() {
-                    parts.push(self.module_name.clone());
+                    total_len += self.module_name.len() + 1;
                 }
-                parts.extend(self.class_stack.clone());
-                parts.push(method_name.to_string());
-                self.add_ref(parts.join("."));
+                for class_name in &self.class_stack {
+                    total_len += class_name.len() + 1;
+                }
+
+                let mut qualified = String::with_capacity(total_len);
+                if !self.module_name.is_empty() {
+                    qualified.push_str(&self.module_name);
+                }
+                for class_name in &self.class_stack {
+                    if !qualified.is_empty() {
+                        qualified.push('.');
+                    }
+                    qualified.push_str(class_name);
+                }
+                if !qualified.is_empty() {
+                    qualified.push('.');
+                }
+                qualified.push_str(attr_name);
+                self.add_ref(&qualified);
             } else {
-                self.add_ref(base_id.to_owned());
-                let full_attr = format!("{}.{}", base_id, node.attr);
-                self.add_ref(full_attr);
+                self.add_ref(base_id);
+                let mut full_attr = String::with_capacity(base_id.len() + 1 + attr_name.len());
+                full_attr.push_str(base_id);
+                full_attr.push('.');
+                full_attr.push_str(attr_name);
+                self.add_ref(&full_attr);
             }
         }
         self.visit_expr(&node.value);
@@ -196,31 +223,23 @@ impl<'a> CytoScnPyVisitor<'a> {
     pub(super) fn visit_string_literal(&mut self, node: &ast::ExprStringLiteral) {
         let s = node.value.to_string();
         if !s.contains(' ') && !s.is_empty() {
-            self.add_ref(s.clone());
+            self.add_ref(&s);
             if !self.module_name.is_empty() {
-                self.add_ref(format!("{}.{}", self.module_name, s));
+                let qualified = format!("{}.{}", self.module_name, s);
+                self.add_ref(&qualified);
             }
 
-            let mut current_word = String::new();
-            for ch in s.chars() {
-                if ch.is_alphanumeric() || ch == '_' {
-                    current_word.push(ch);
-                } else if !current_word.is_empty() {
-                    if current_word.chars().next().is_some_and(char::is_uppercase) {
-                        self.add_ref(current_word.clone());
-                        if !self.module_name.is_empty() {
-                            self.add_ref(format!("{}.{}", self.module_name, current_word));
-                        }
-                    }
-                    current_word.clear();
-                }
+            if !s.chars().any(char::is_uppercase) {
+                return;
             }
-            if !current_word.is_empty()
-                && current_word.chars().next().is_some_and(char::is_uppercase)
-            {
-                self.add_ref(current_word.clone());
-                if !self.module_name.is_empty() {
-                    self.add_ref(format!("{}.{}", self.module_name, current_word));
+
+            for token in s.split(|ch: char| !ch.is_alphanumeric() && ch != '_') {
+                if token.chars().next().is_some_and(char::is_uppercase) {
+                    self.add_ref(token);
+                    if !self.module_name.is_empty() {
+                        let qualified = format!("{}.{}", self.module_name, token);
+                        self.add_ref(&qualified);
+                    }
                 }
             }
         }

--- a/cytoscnpy/src/visitor/function_def.rs
+++ b/cytoscnpy/src/visitor/function_def.rs
@@ -18,7 +18,7 @@ impl<'a> CytoScnPyVisitor<'a> {
         self.enter_scope(ScopeType::Function(CompactString::from(name)));
 
         if self.mark_framework_function(decorator_list) {
-            self.add_ref(qualified_name.clone());
+            self.add_ref(&qualified_name);
         }
 
         let skip_parameters = self.should_skip_parameters(decorator_list);

--- a/cytoscnpy/src/visitor/scope_ops.rs
+++ b/cytoscnpy/src/visitor/scope_ops.rs
@@ -126,8 +126,8 @@ impl<'a> CytoScnPyVisitor<'a> {
     }
 
     /// Records a reference to a name by incrementing its count.
-    pub fn add_ref(&mut self, name: String) {
-        *self.references.entry(name).or_insert(0) += 1;
+    pub fn add_ref(&mut self, name: &str) {
+        *self.references.entry(name.to_owned()).or_insert(0) += 1;
     }
 
     /// Returns the fully qualified ID of the current scope.

--- a/cytoscnpy/src/visitor/stmt_assignments.rs
+++ b/cytoscnpy/src/visitor/stmt_assignments.rs
@@ -16,10 +16,10 @@ impl<'a> CytoScnPyVisitor<'a> {
                     let id = name_node.id.as_str();
                     if id.starts_with("HAS_") || id.starts_with("HAVE_") {
                         self.optional_dependency_flags.insert(id.to_owned());
-                        self.add_ref(id.to_owned());
+                        self.add_ref(id);
                         if !self.module_name.is_empty() {
                             let qualified = format!("{}.{}", self.module_name, id);
-                            self.add_ref(qualified);
+                            self.add_ref(&qualified);
                         }
                     }
                 }
@@ -36,10 +36,10 @@ impl<'a> CytoScnPyVisitor<'a> {
                         .is_some_and(|s| s.global_declarations.contains(name_node.id.as_str()));
 
                     if is_global {
-                        self.add_ref(name_node.id.to_string());
+                        self.add_ref(name_node.id.as_str());
                         if !self.module_name.is_empty() {
                             let qualified = format!("{}.{}", self.module_name, name_node.id);
-                            self.add_ref(qualified);
+                            self.add_ref(&qualified);
                         }
                     } else {
                         let qualified_name = self.get_qualified_name(&name_node.id);
@@ -60,7 +60,7 @@ impl<'a> CytoScnPyVisitor<'a> {
 
                         if !self.class_stack.is_empty() && self.function_stack.is_empty() {
                             if let Some(true) = self.model_class_stack.last() {
-                                self.add_ref(qualified_name);
+                                self.add_ref(&qualified_name);
                             }
                         }
                     }
@@ -77,7 +77,7 @@ impl<'a> CytoScnPyVisitor<'a> {
                     for target in &node.targets {
                         if let Expr::Name(name_node) = target {
                             let qualified_name = self.get_qualified_name(&name_node.id);
-                            self.add_ref(qualified_name);
+                            self.add_ref(&qualified_name);
                         }
                     }
                 }
@@ -161,7 +161,7 @@ impl<'a> CytoScnPyVisitor<'a> {
                 && self.function_stack.is_empty()
                 && self.model_class_stack.last().is_some_and(|v| *v)
             {
-                self.add_ref(qualified_name);
+                self.add_ref(&qualified_name);
             }
         } else {
             self.visit_expr(&node.target);
@@ -186,7 +186,7 @@ impl<'a> CytoScnPyVisitor<'a> {
         if is_type_alias {
             if let Expr::Name(name_node) = &*node.target {
                 let qualified_name = self.get_qualified_name(&name_node.id);
-                self.add_ref(qualified_name);
+                self.add_ref(&qualified_name);
             }
         }
     }

--- a/cytoscnpy/src/visitor/stmt_defs.rs
+++ b/cytoscnpy/src/visitor/stmt_defs.rs
@@ -112,10 +112,10 @@ impl<'a> CytoScnPyVisitor<'a> {
         for base in node.bases() {
             self.visit_expr(base);
             if let Expr::Name(base_name) = base {
-                self.add_ref(base_name.id.to_string());
+                self.add_ref(base_name.id.as_str());
                 if !self.module_name.is_empty() {
                     let qualified_base = format!("{}.{}", self.module_name, base_name.id);
-                    self.add_ref(qualified_base);
+                    self.add_ref(&qualified_base);
                 }
             }
         }
@@ -132,10 +132,10 @@ impl<'a> CytoScnPyVisitor<'a> {
                 has_metaclass = true;
             }
             if let Expr::Name(kw_name) = &keyword.value {
-                self.add_ref(kw_name.id.to_string());
+                self.add_ref(kw_name.id.as_str());
                 if !self.module_name.is_empty() {
                     let qualified_kw = format!("{}.{}", self.module_name, kw_name.id);
-                    self.add_ref(qualified_kw);
+                    self.add_ref(&qualified_kw);
                 }
             }
         }
@@ -147,8 +147,8 @@ impl<'a> CytoScnPyVisitor<'a> {
 
         for base_class in &base_classes {
             if self.metaclass_classes.contains(base_class) {
-                self.add_ref(qualified_name);
-                self.add_ref(name.to_string());
+                self.add_ref(&qualified_name);
+                self.add_ref(name.as_str());
                 break;
             }
         }

--- a/cytoscnpy/src/visitor/stmt_imports.rs
+++ b/cytoscnpy/src/visitor/stmt_imports.rs
@@ -33,8 +33,8 @@ impl<'a> CytoScnPyVisitor<'a> {
                 } else {
                     format!("{}.{}", self.module_name, simple_name)
                 };
-                self.add_ref(qualified_name);
-                self.add_ref(simple_name.to_string());
+                self.add_ref(&qualified_name);
+                self.add_ref(simple_name.as_str());
             }
         }
     }
@@ -72,7 +72,7 @@ impl<'a> CytoScnPyVisitor<'a> {
                 self.import_bindings
                     .insert(self.get_qualified_name(asname.as_str()), full_name.clone());
                 // Importing a symbol is itself a static dependency on that source symbol.
-                self.add_ref(full_name);
+                self.add_ref(&full_name);
             } else {
                 self.alias_map
                     .insert(asname.to_string(), alias.name.to_string());
@@ -80,7 +80,7 @@ impl<'a> CytoScnPyVisitor<'a> {
                     self.get_qualified_name(asname.as_str()),
                     alias.name.to_string(),
                 );
-                self.add_ref(alias.name.to_string());
+                self.add_ref(alias.name.as_str());
             }
 
             if self.in_import_error_block {
@@ -89,8 +89,8 @@ impl<'a> CytoScnPyVisitor<'a> {
                 } else {
                     format!("{}.{}", self.module_name, asname)
                 };
-                self.add_ref(qualified_name);
-                self.add_ref(asname.to_string());
+                self.add_ref(&qualified_name);
+                self.add_ref(asname.as_str());
             }
         }
     }

--- a/cytoscnpy/src/visitor/stmt_misc.rs
+++ b/cytoscnpy/src/visitor/stmt_misc.rs
@@ -7,7 +7,7 @@ impl<'a> CytoScnPyVisitor<'a> {
                 if name_node.ctx.is_load() {
                     let name = name_node.id.to_string();
                     if let Some(qualified) = self.resolve_name(&name) {
-                        self.add_ref(qualified);
+                        self.add_ref(&qualified);
                     }
                 }
             }
@@ -42,10 +42,10 @@ impl<'a> CytoScnPyVisitor<'a> {
             if let Some(scope) = self.scope_stack.last_mut() {
                 scope.global_declarations.insert(name.id.to_string());
             }
-            self.add_ref(name.id.to_string());
+            self.add_ref(name.id.as_str());
             if !self.module_name.is_empty() {
                 let qualified = format!("{}.{}", self.module_name, name.id);
-                self.add_ref(qualified);
+                self.add_ref(&qualified);
             }
         }
     }


### PR DESCRIPTION
- Refine unreachable detection to exclude nested callables and captured values
- Add explicitly_called_nodes to ReachabilityContext for better reachability
- Split unused_functions into unreachable and unused in reports and summary
- Fix taint analysis: pass analyzer and file_path, collect findings in context- Make network timeout rule case-sensitive (only lowercase methods matched)
- Normalize base class names to handle generics (e.g., Protocol[T])
- Handle walrus operator (Expr::Named) in expression traversal
- Update tests: add regression tests and adjust existing tests/snapshots