### PR TITLE
chore(vscode): bump version to 0.1.19 and update dependencies

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,41 +30,37 @@ jobs:
           comment-summary-in-pr: always
           # License check - allow common permissive licenses
           # Allow known unavailable vulnerabilities for Python 3.8 support
+          # Allow known unavailable vulnerabilities for Python 3.8 support:
+          # setuptools path traversal, urllib3 redirect/proxy/decompression/streaming DoS,
+          # filelock TOCTOU, pip path traversal (all require Py 3.9+ to fix)
           allow-ghsas: >-
-            # setuptools path traversal (fix requires Py 3.9+)
             GHSA-5rjg-fvgr-3xxf,
-            # urllib3: redirect body handling (fix requires Py 3.9+)
             GHSA-g4mx-q9vg-27p4,
-            # urllib3: Proxy-Authorization leakage (fix requires Py 3.9+)
             GHSA-34jh-p97f-mpxf,
-            # urllib3: decompression chain DoS (fix requires Py 3.9+)
             GHSA-gm62-xv2j-4w53,
-            # urllib3: streaming API highly compressed data DoS (fix requires Py 3.9+)
             GHSA-2xpw-w6gg-jr37,
-            # filelock: TOCTOU race condition (fix requires Py 3.9+)
             GHSA-pw2r-r8wx-5mcc,
-            # pip: path traversal in fallback tar extraction (fix requires Py 3.9+)
             GHSA-4xh5-x5gv-qwph
 
           # License check - allow common permissive licenses
-          allow-licenses:
-            - MIT
-            - Apache-2.0
-            - BSD-2-Clause
-            - BSD-3-Clause
-            - ISC
-            - MPL-2.0
-            - 0BSD
-            - Unlicense
-            - CC0-1.0
-            - Python-2.0
-            - PSF-2.0
+          allow-licenses: >-
+            MIT,
+            Apache-2.0,
+            BSD-2-Clause,
+            BSD-3-Clause,
+            ISC,
+            MPL-2.0,
+            0BSD,
+            Unlicense,
+            CC0-1.0,
+            Python-2.0,
+            PSF-2.0
 
-          # Handle packages with unknown/complex licenses explicitly
-          allow-dependencies-licenses:
-            - cyclonedx-python-lib: Apache-2.0 AND Python-2.0
-            - pyparsing: MIT AND Python-2.0
-            - basedpyright: MIT
+          # Handle packages with unknown/complex licenses explicitly (PURL format required)
+          allow-dependencies-licenses: >-
+            pkg:pypi/cyclonedx-python-lib@*: Apache-2.0 AND Python-2.0,
+            pkg:pypi/pyparsing@*: MIT AND Python-2.0,
+            pkg:pypi/basedpyright@*: MIT
 
           # Warn on low OpenSSF scorecard
           warn-on-openssf-scorecard-level: 3

--- a/.pip-audit-ignore
+++ b/.pip-audit-ignore
@@ -1,6 +1,3 @@
 # pip-audit ignore list
 # Format: one CVE/GHSA ID per line; lines starting with '#' and blank lines are ignored.
 # Remove an entry once a fixed version is available and you have upgraded.
-
-# pygments 2.19.2 - no fix released yet (2026-03-25)
-CVE-2026-4539

--- a/editors/vscode/cytoscnpy/package-lock.json
+++ b/editors/vscode/cytoscnpy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cytoscnpy",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cytoscnpy",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
@@ -878,6 +878,7 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -1110,6 +1111,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2042,6 +2044,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4564,9 +4567,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -5128,6 +5131,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5258,6 +5262,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/editors/vscode/cytoscnpy/package.json
+++ b/editors/vscode/cytoscnpy/package.json
@@ -195,7 +195,7 @@
     "test": "vscode-test"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "7.0.5"
   },
   "devDependencies": {
     "@types/vscode": "^1.96.0",

--- a/editors/vscode/cytoscnpy/package.json
+++ b/editors/vscode/cytoscnpy/package.json
@@ -3,7 +3,7 @@
   "publisher": "djinn09",
   "displayName": "CytoScnPy",
   "description": "Python static analyzer with MCP server for GitHub Copilot. Real-time dead code detection, security scanning, and code quality metrics.",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "icon": "assets/icon.png",
   "repository": {
     "type": "git",
@@ -195,7 +195,7 @@
     "test": "vscode-test"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.5"
   },
   "devDependencies": {
     "@types/vscode": "^1.96.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -47,7 +47,7 @@ prek==0.3.3
 psutil==7.2.2
 py-serializable==2.1.0
 pygments==2.20.0
-pymdown-extensions==10.21
+pymdown-extensions==10.21.2
 pyparsing==3.3.2
 pytest==9.0.2
 pytest-cov==7.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -46,7 +46,7 @@ poethepoet==0.41.0
 prek==0.3.3
 psutil==7.2.2
 py-serializable==2.1.0
-pygments==2.19.2
+pygments==2.20.0
 pymdown-extensions==10.21
 pyparsing==3.3.2
 pytest==9.0.2

--- a/uv.lock
+++ b/uv.lock
@@ -1044,11 +1044,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1053,15 +1053,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21"
+version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updated the VSCode extension package to 0.1.19, bumped serialize-javascript dependency to ^7.0.5, updated pygments to 2.20.0, and removed the expired CVE entry from the pip-audit ignore list.