### PR TITLE
feat(analyzer): add runtime protocol hint support and include_tests r…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "cytoscnpy"
-version = "1.2.19"
+version = "1.2.20"
 dependencies = [
  "anyhow",
  "askama",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "cytoscnpy-cli"
-version = "1.2.19"
+version = "1.2.20"
 dependencies = [
  "anyhow",
  "cytoscnpy",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "cytoscnpy-mcp"
-version = "1.2.19"
+version = "1.2.20"
 dependencies = [
  "cytoscnpy",
  "rmcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cytoscnpy", "cytoscnpy-cli", "cytoscnpy-mcp"]
 resolver = "2"
 
 [workspace.package]
-version = "1.2.19"
+version = "1.2.20"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/cytoscnpy/src/analyzer/aggregation/mod.rs
+++ b/cytoscnpy/src/analyzer/aggregation/mod.rs
@@ -57,9 +57,11 @@ impl CytoScnPy {
         let fixture_definition_names = state.fixture_definition_names();
         let reachability = build_reachability(
             &state.all_defs,
+            &state.ref_counts,
             &state.all_protocols,
             &state.dynamic_imported_modules,
             &state.global_call_graph,
+            self.include_tests,
         );
 
         let mut classified = classify_definitions(

--- a/cytoscnpy/src/analyzer/aggregation/reachability.rs
+++ b/cytoscnpy/src/analyzer/aggregation/reachability.rs
@@ -2,6 +2,8 @@ use crate::taint::call_graph::CallGraph;
 use crate::visitor::Definition;
 use rustc_hash::{FxHashMap, FxHashSet};
 
+pub(super) const RUNTIME_PROTOCOL_REF_PREFIX: &str = "__csp_runtime_protocol__.";
+
 pub(super) struct ReachabilityContext {
     pub(super) implicitly_used_methods: FxHashSet<String>,
     pub(super) reachable_nodes: FxHashSet<String>,
@@ -10,18 +12,23 @@ pub(super) struct ReachabilityContext {
 
 pub(super) fn build_reachability(
     definitions: &[Definition],
+    ref_counts: &FxHashMap<String, usize>,
     protocol_methods: &FxHashMap<String, FxHashSet<String>>,
     dynamic_imported_modules: &FxHashSet<String>,
     call_graph: &CallGraph,
+    include_tests: bool,
 ) -> ReachabilityContext {
     let class_methods = collect_class_methods(definitions);
-    let implicitly_used_methods = collect_implicitly_used_methods(&class_methods, protocol_methods);
+    let runtime_protocol_hints = collect_runtime_protocol_hints(ref_counts);
+    let implicitly_used_methods =
+        collect_implicitly_used_methods(&class_methods, protocol_methods, &runtime_protocol_hints);
     let reachable_nodes = collect_reachable_nodes(
         definitions,
         &class_methods,
         &implicitly_used_methods,
         dynamic_imported_modules,
         call_graph,
+        include_tests,
     );
     let explicitly_called_nodes = collect_explicitly_called_nodes(call_graph);
 
@@ -67,6 +74,7 @@ fn collect_class_methods(definitions: &[Definition]) -> FxHashMap<String, FxHash
 fn collect_implicitly_used_methods(
     class_methods: &FxHashMap<String, FxHashSet<String>>,
     protocol_methods: &FxHashMap<String, FxHashSet<String>>,
+    runtime_protocol_hints: &FxHashSet<String>,
 ) -> FxHashSet<String> {
     let mut method_to_protocols: FxHashMap<String, Vec<&String>> = FxHashMap::default();
 
@@ -95,12 +103,16 @@ fn collect_implicitly_used_methods(
             if let Some(proto_methods) = protocol_methods.get(proto_name) {
                 let intersection_count = methods.intersection(proto_methods).count();
                 let proto_len = proto_methods.len();
-                if proto_len > 0 && intersection_count >= 3 {
+                let runtime_checked = protocol_hint_matches(proto_name, runtime_protocol_hints);
+                let passes_similarity_threshold = proto_len > 0 && intersection_count >= 3 && {
                     let ratio = intersection_count as f64 / proto_len as f64;
-                    if ratio >= 0.7 {
-                        for method in methods.intersection(proto_methods) {
-                            implicitly_used_methods.insert(format!("{class_name}.{method}"));
-                        }
+                    ratio >= 0.7
+                };
+                let passes_runtime_threshold = runtime_checked && intersection_count > 0;
+
+                if passes_similarity_threshold || passes_runtime_threshold {
+                    for method in methods.intersection(proto_methods) {
+                        implicitly_used_methods.insert(format!("{class_name}.{method}"));
                     }
                 }
             }
@@ -110,19 +122,41 @@ fn collect_implicitly_used_methods(
     implicitly_used_methods
 }
 
+fn collect_runtime_protocol_hints(ref_counts: &FxHashMap<String, usize>) -> FxHashSet<String> {
+    ref_counts
+        .keys()
+        .filter_map(|key| key.strip_prefix(RUNTIME_PROTOCOL_REF_PREFIX))
+        .map(std::borrow::ToOwned::to_owned)
+        .collect()
+}
+
+fn protocol_hint_matches(proto_name: &str, runtime_protocol_hints: &FxHashSet<String>) -> bool {
+    runtime_protocol_hints.contains(proto_name)
+        || runtime_protocol_hints
+            .iter()
+            .any(|hint| hint.ends_with(&format!(".{proto_name}")))
+}
+
 fn collect_reachable_nodes(
     definitions: &[Definition],
     class_methods: &FxHashMap<String, FxHashSet<String>>,
     implicitly_used_methods: &FxHashSet<String>,
     dynamic_imported_modules: &FxHashSet<String>,
     call_graph: &CallGraph,
+    include_tests: bool,
 ) -> FxHashSet<String> {
     let mut roots = FxHashSet::default();
     let mut method_simple_to_full: FxHashMap<String, Vec<String>> = FxHashMap::default();
+    let mut callable_simple_to_full: FxHashMap<String, Vec<String>> = FxHashMap::default();
 
     for def in definitions {
         if def.def_type == "method" {
             method_simple_to_full
+                .entry(def.simple_name.clone())
+                .or_default()
+                .push(def.full_name.clone());
+        } else if def.def_type == "function" || def.def_type == "class" {
+            callable_simple_to_full
                 .entry(def.simple_name.clone())
                 .or_default()
                 .push(def.full_name.clone());
@@ -132,6 +166,7 @@ fn collect_reachable_nodes(
             || def.is_framework_managed
             || def.confidence == 0
             || implicitly_used_methods.contains(&def.full_name)
+            || (include_tests && crate::utils::is_test_path(&def.file.to_string_lossy()))
             || dynamic_imported_modules.iter().any(|module| {
                 !module.is_empty()
                     && (def.full_name == *module
@@ -176,8 +211,18 @@ fn collect_reachable_nodes(
                             }
                         }
                     }
-                } else if call_graph.nodes.contains_key(call) && !reachable_nodes.contains(call) {
-                    stack.push(call.clone());
+                } else if call_graph.nodes.contains_key(call) {
+                    if !reachable_nodes.contains(call) {
+                        stack.push(call.clone());
+                    }
+                } else if !call.contains('.') {
+                    if let Some(candidates) = callable_simple_to_full.get(call) {
+                        for candidate in candidates {
+                            if !reachable_nodes.contains(candidate) {
+                                stack.push(candidate.clone());
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/cytoscnpy/src/visitor/expr.rs
+++ b/cytoscnpy/src/visitor/expr.rs
@@ -1,6 +1,6 @@
-#![allow(missing_docs)]
-
 use super::*;
+
+const RUNTIME_PROTOCOL_REF_PREFIX: &str = "__csp_runtime_protocol__.";
 
 impl<'a> CytoScnPyVisitor<'a> {
     pub(super) fn visit_name_expr(&mut self, node: &ast::ExprName) {
@@ -87,6 +87,10 @@ impl<'a> CytoScnPyVisitor<'a> {
                 }
             }
 
+            if (name == "isinstance" || name == "issubclass") && node.arguments.args.len() >= 2 {
+                self.record_runtime_protocol_hints(&node.arguments.args[1]);
+            }
+
             if name == "__import__" {
                 if let Some(Expr::StringLiteral(module_str)) = node.arguments.args.first() {
                     self.dynamic_imports.push(module_str.value.to_string());
@@ -142,6 +146,36 @@ impl<'a> CytoScnPyVisitor<'a> {
                 _ => false,
             },
             _ => false,
+        }
+    }
+
+    fn runtime_protocol_name(expr: &Expr) -> Option<String> {
+        match expr {
+            Expr::Name(name) => Some(name.id.to_string()),
+            Expr::Attribute(attr) => {
+                if let Expr::Name(base_name) = &*attr.value {
+                    Some(format!("{}.{}", base_name.id, attr.attr))
+                } else {
+                    Some(attr.attr.to_string())
+                }
+            }
+            Expr::Subscript(subscript) => Self::runtime_protocol_name(&subscript.value),
+            _ => None,
+        }
+    }
+
+    fn record_runtime_protocol_hints(&mut self, type_expr: &Expr) {
+        match type_expr {
+            Expr::Tuple(tuple_expr) => {
+                for element in &tuple_expr.elts {
+                    self.record_runtime_protocol_hints(element);
+                }
+            }
+            _ => {
+                if let Some(protocol_name) = Self::runtime_protocol_name(type_expr) {
+                    self.add_ref(&format!("{RUNTIME_PROTOCOL_REF_PREFIX}{protocol_name}"));
+                }
+            }
         }
     }
 

--- a/cytoscnpy/tests/include_tests_reachability_regression_test.rs
+++ b/cytoscnpy/tests/include_tests_reachability_regression_test.rs
@@ -1,0 +1,66 @@
+//! Regression tests for test-root reachability behavior.
+#![allow(clippy::unwrap_used)]
+
+use cytoscnpy::analyzer::CytoScnPy;
+use cytoscnpy::config::ProjectType;
+use std::fs::{self, File};
+use std::io::Write;
+use tempfile::TempDir;
+
+fn project_tempdir() -> TempDir {
+    let mut target_dir = std::env::current_dir().unwrap();
+    target_dir.push("target");
+    target_dir.push("test-include-tests-roots-tmp");
+    fs::create_dir_all(&target_dir).unwrap();
+    tempfile::Builder::new()
+        .prefix("include_tests_roots_")
+        .tempdir_in(target_dir)
+        .unwrap()
+}
+
+#[test]
+fn source_symbols_referenced_only_by_tests_are_reachable_when_include_tests_enabled() {
+    let dir = project_tempdir();
+    let pkg_dir = dir.path().join("pkg");
+    let tests_dir = dir.path().join("tests");
+    fs::create_dir_all(&pkg_dir).unwrap();
+    fs::create_dir_all(&tests_dir).unwrap();
+
+    let mut init_file = File::create(pkg_dir.join("__init__.py")).unwrap();
+    writeln!(init_file, "from .service import use_from_tests").unwrap();
+
+    let mut source_file = File::create(pkg_dir.join("service.py")).unwrap();
+    writeln!(
+        source_file,
+        r"
+def use_from_tests() -> int:
+    return 7
+"
+    )
+    .unwrap();
+
+    let mut test_file = File::create(tests_dir.join("test_service.py")).unwrap();
+    writeln!(
+        test_file,
+        r"
+from pkg.service import use_from_tests
+
+def test_use_from_tests() -> None:
+    assert use_from_tests() == 7
+"
+    )
+    .unwrap();
+
+    let mut analyzer = CytoScnPy::default().with_confidence(0).with_tests(true);
+    analyzer.config.cytoscnpy.project_type = Some(ProjectType::Application);
+    let result = analyzer.analyze(dir.path());
+
+    let unused_source_function = result
+        .unused_functions
+        .iter()
+        .find(|d| d.full_name == "pkg.service.use_from_tests");
+    assert!(
+        unused_source_function.is_none(),
+        "Functions referenced only by tests should not be unreachable when include_tests=true"
+    );
+}

--- a/cytoscnpy/tests/protocol_signature_regression_test.rs
+++ b/cytoscnpy/tests/protocol_signature_regression_test.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::unwrap_used)]
 
 use cytoscnpy::analyzer::CytoScnPy;
+use cytoscnpy::config::ProjectType;
 use std::fs::File;
 use std::io::Write;
 use tempfile::TempDir;
@@ -59,5 +60,132 @@ class ConcreteRepo:
     assert!(
         protocol_param.is_none(),
         "Protocol method parameters should not be reported as unused parameters"
+    );
+}
+
+#[test]
+fn test_runtime_checkable_protocol_isinstance_marks_required_method_as_used() {
+    let dir = project_tempdir();
+    let file_path = dir.path().join("runtime_protocol.py");
+    let mut file = File::create(&file_path).unwrap();
+
+    writeln!(
+        file,
+        r#"
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class Runner(Protocol):
+    def run(self) -> str: ...
+
+class EchoRunner:
+    def run(self) -> str:
+        return "ok"
+
+def accepts_runtime_checked(value: object) -> bool:
+    return isinstance(value, Runner)
+
+accepts_runtime_checked(EchoRunner())
+"#
+    )
+    .unwrap();
+
+    let mut analyzer = CytoScnPy::default().with_confidence(0).with_tests(false);
+    analyzer.config.cytoscnpy.project_type = Some(ProjectType::Application);
+    let result = analyzer.analyze(dir.path());
+
+    let echo_run_method = result
+        .unused_methods
+        .iter()
+        .find(|d| d.full_name == "runtime_protocol.EchoRunner.run");
+    assert!(
+        echo_run_method.is_none(),
+        "Runtime protocol checks should keep required implementing methods reachable"
+    );
+}
+
+#[test]
+fn test_casted_protocol_in_function_flow_is_not_reported_unused() {
+    let dir = project_tempdir();
+    let file_path = dir.path().join("cast_protocol_flow.py");
+    let mut file = File::create(&file_path).unwrap();
+
+    writeln!(
+        file,
+        r#"
+from typing import Protocol, cast, runtime_checkable
+
+@runtime_checkable
+class Runner(Protocol):
+    def run(self) -> str: ...
+
+class Impl:
+    def run(self) -> str:
+        return "ok"
+
+def call_runner(value: object) -> str:
+    if not isinstance(value, Runner):
+        return "nope"
+    runner = cast(Runner, value)
+    return runner.run()
+
+call_runner(Impl())
+"#
+    )
+    .unwrap();
+
+    let mut analyzer = CytoScnPy::default().with_confidence(0).with_tests(false);
+    analyzer.config.cytoscnpy.project_type = Some(ProjectType::Application);
+    let result = analyzer.analyze(dir.path());
+
+    let impl_run_method = result
+        .unused_methods
+        .iter()
+        .find(|d| d.full_name == "cast_protocol_flow.Impl.run");
+    assert!(
+        impl_run_method.is_none(),
+        "Protocol + cast flow in function scope should keep implementation method reachable"
+    );
+}
+
+#[test]
+fn test_runtime_checkable_protocol_cast_only_flow_is_not_reported_unused() {
+    let dir = project_tempdir();
+    let file_path = dir.path().join("cast_only_runtime_protocol.py");
+    let mut file = File::create(&file_path).unwrap();
+
+    writeln!(
+        file,
+        r#"
+from typing import Protocol, cast, runtime_checkable
+
+@runtime_checkable
+class Runner(Protocol):
+    def run(self) -> str: ...
+
+class Impl:
+    def run(self) -> str:
+        return "ok"
+
+def call_runner(value: object) -> str:
+    runner = cast(Runner, value)
+    return runner.run()
+
+call_runner(Impl())
+"#
+    )
+    .unwrap();
+
+    let mut analyzer = CytoScnPy::default().with_confidence(0).with_tests(false);
+    analyzer.config.cytoscnpy.project_type = Some(ProjectType::Application);
+    let result = analyzer.analyze(dir.path());
+
+    let impl_run_method = result
+        .unused_methods
+        .iter()
+        .find(|d| d.full_name == "cast_only_runtime_protocol.Impl.run");
+    assert!(
+        impl_run_method.is_none(),
+        "Cast-only runtime-checkable protocol flow should keep implementation method reachable"
     );
 }

--- a/editors/vscode/cytoscnpy/package.json
+++ b/editors/vscode/cytoscnpy/package.json
@@ -3,7 +3,7 @@
   "publisher": "djinn09",
   "displayName": "CytoScnPy",
   "description": "Python static analyzer with MCP server for GitHub Copilot. Real-time dead code detection, security scanning, and code quality metrics.",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "icon": "assets/icon.png",
   "repository": {
     "type": "git",


### PR DESCRIPTION
…eachability

Add support for @runtime_checkable protocols by capturing runtime protocol hints during parsing and using them to mark required methods reachable. Extend reachability analysis to include symbols referenced only by tests when the include_tests flag is enabled. Bump workspace and VSC extension versions to 1.20