### PR TITLE
docs: update documentation links, python requirements and placeholders

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to the Rust implementation of CytoSc
 
 - **Rust**: Version 1.70 or higher. Install via [rustup.rs](https://rustup.rs).
 - **Cargo**: Comes with Rust.
-- **Python**: Version 3.8 or higher (for hybrid packaging).
+- **Python**: Version 3.10 or higher (matches `pyproject.toml`).
 - **UV or pip**: For Python package management.
 - **Maturin**: For building PyO3 extensions.
 - **Prek**: Rust-based pre-commit runner. Install via `cargo install prek`. Note: `prek` is a standalone binary that automatically handles its own Python runtimes and virtual environments for hooks, so no manual Python environment management is needed for the hooks themselves.
@@ -69,10 +69,11 @@ Thank you for your interest in contributing to the Rust implementation of CytoSc
 
    ```bash
    # Using uv (fast)
-   uv pip install -e ".[dev]"
+   uv sync --group dev
 
    # Or using pip
-   pip install -e ".[dev]"
+   pip install maturin pytest
+   maturin develop -m cytoscnpy/Cargo.toml
    ```
 
 4. **Install Pre-commit Hooks:**
@@ -89,7 +90,7 @@ The MCP server implementation is located in `cytoscnpy-mcp/`. It allows CytoScnP
 ### Running the MCP Server locally
 
 ```bash
-cargo run --bin cytoscnpy-mcp
+cargo run -p cytoscnpy-cli -- mcp-server
 ```
 
 ### Testing the MCP Server
@@ -245,7 +246,7 @@ To create a `.vsix` installer:
 vsce package
 ```
 
-This will generate `cytoscnpy-0.0.1.vsix`.
+This will generate `cytoscnpy-<version>.vsix`.
 
 **Publishing:**
 To publish to the VS Code Marketplace, run `vsce publish` after authentication with `vsce login <publisher>`.
@@ -580,7 +581,7 @@ uv run --with pytest pytest python/tests
 
 # Or with virtual environment activated
 # Install dev dependencies
-uv pip install -e ".[dev]"
+uv sync --group dev
 
 # Run all Python CLI tests
 pytest python/tests/ -v

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Security Audit](https://github.com/djinn-soul/CytoScnPy/actions/workflows/security.yml/badge.svg)](https://github.com/djinn-soul/CytoScnPy/actions/workflows/security.yml)
 [![Docs](https://github.com/djinn-soul/CytoScnPy/actions/workflows/docs.yml/badge.svg)](https://github.com/djinn-soul/CytoScnPy/actions/workflows/docs.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Version](https://img.shields.io/badge/version-1.2.7-green.svg)](https://github.com/djinn-soul/CytoScnPy)
+[![PyPI](https://img.shields.io/pypi/v/cytoscnpy)](https://pypi.org/project/cytoscnpy/)
 ![AI Assisted](https://img.shields.io/badge/AI--Assisted-Gemini-blue)
 
 A fast, lightweight static analyzer for Python codebase. It’s built in Rust with Python integration and detection of dead code, security issues, and code quality issue, along with useful quality metrics.
@@ -95,8 +95,6 @@ Integrate CytoScnPy directly into your GitHub Actions workflow:
 
 ## Usage
 
-> [!IMPORTANT] **Behavioral Change**: Starting from version 1.2.2, tests are **excluded by default** across both the CLI and the library API to reduce noise in production analysis. Use the `--include-tests` flag or set `include_tests = true` in your configuration to scan test files.
-
 ### Command Line
 
 ```bash
@@ -137,7 +135,7 @@ cytoscnpy . --fix -a                 # Apply changes (short flag)
 cytoscnpy . --html --secrets --danger
 
 # Pre-commit integration
-# See https://djinn-soul.github.io/CytoScnPy/pre-commit/ for setup
+# See https://djinn09.github.io/CytoScnPy/pre-commit/ for setup
 ```
 
 **Common Options:**
@@ -152,7 +150,8 @@ cytoscnpy . --html --secrets --danger
 | `-a, --apply`   | Apply fixes to files (use with `--fix`)         |
 | `--json`        | Output results in machine-readable JSON         |
 
-> [!TIP] > **[View the Full CLI Reference](docs/CLI.md)** for detailed usage, advanced configuration, and quality gate options.
+> [!TIP]
+> **[View the Full CLI Reference](docs/CLI.md)** for detailed usage, advanced configuration, and quality gate options.
 
 **CI/CD Gate Options:**
 
@@ -166,8 +165,6 @@ cytoscnpy . --html --secrets --danger
 | `--max-args <N>`       | Exit code 1 if any function has > N args   |
 | `--max-lines <N>`      | Exit code 1 if any function has > N lines  |
 
-> **Full CLI Reference:** See [docs/CLI.md](docs/CLI.md) for complete command documentation.
-
 ### Metric Subcommands
 
 ```bash
@@ -178,6 +175,8 @@ cytoscnpy mi .                     # Maintainability Index
 cytoscnpy stats . --all            # Full project report (secrets, danger, quality)
 cytoscnpy stats . --all -o report.md  # Save report to file
 cytoscnpy files .                  # Per-file metrics table
+cytoscnpy deps .                   # Dependency analysis
+cytoscnpy init                     # Scaffold config in the current project
 ```
 
 > **Tip**: Add `--json` for machine-readable output, `--exclude-folder <DIR>` to skip directories globally, or `--ignore <PATTERN>` for subcommand-specific glob filtering.
@@ -212,7 +211,7 @@ max_args = 5          # Max arguments per function
 max_complexity = 10   # Max cyclomatic complexity
 max_nesting = 4       # Max indentation depth
 min_mi = 65.0         # Minimum Maintainability Index
-ignore = ["R001"]     # Ignore specific rule IDs
+ignore = ["CSP-P003"] # Ignore specific rule IDs
 
 # Advanced Secret Scanning
 [cytoscnpy.secrets_config]
@@ -280,13 +279,9 @@ cytoscnpy . --fail-threshold 5 --quiet
 
 > See [benchmark/README.md](benchmark/README.md) for detailed comparison against Vulture, Flake8, Pylint, Ruff, and others.
 
-## Testing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md#testing) for testing instructions.
-
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing instructions, and guidelines.
 
 ## License
 
@@ -294,7 +289,7 @@ Apache-2.0 License - see [License](License) file for details.
 
 ## Links
 
-- **Documentation**: [CytoScnPy](https://djinn-soul.github.io/CytoScnPy/)
+- **Documentation**: [CytoScnPy](https://djinn09.github.io/CytoScnPy/)
 - **PyPI**: [PyPi](https://pypi.org/project/cytoscnpy/)
 - **VS Code Extension**: [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=djinn09.cytoscnpy)
 - **Roadmap**: [docs/roadmap.md](docs/roadmap.md)

--- a/Security.md
+++ b/Security.md
@@ -6,4 +6,4 @@ CytoScnPy is a security tool, and we take the security of our users seriously.
 
 If you have found a security vulnerability in CytoScnPy, please **do not** create a public issue. Instead, please report it via one of the following methods:
 
-- **GitHub Security Advisory**: Use the "Report a vulnerability" button in the [Security tab](https://github.com/djinn09/CytoScnPy/security/advisories/new).
+- **GitHub Security Advisory**: Use the "Report a vulnerability" button in the [Security tab](https://github.com/djinn-soul/CytoScnPy/security/advisories/new).

--- a/cytoscnpy-mcp/README.md
+++ b/cytoscnpy-mcp/README.md
@@ -19,7 +19,7 @@ The MCP server is available in the standalone CLI binary:
 
 ```bash
 # Install (Linux/macOS)
-curl -fsSL https://raw.githubusercontent.com/djinn09/CytoScnPy/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/djinn-soul/CytoScnPy/main/install.sh | bash
 
 # Run MCP server (standalone CLI)
 cytoscnpy mcp-server
@@ -37,7 +37,7 @@ Install the [CytoScnPy VS Code extension](../editors/vscode/cytoscnpy/README.md)
 
 ```bash
 # Install
-curl -fsSL https://raw.githubusercontent.com/djinn09/CytoScnPy/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/djinn-soul/CytoScnPy/main/install.sh | bash
 
 # Start MCP server
 cytoscnpy mcp-server
@@ -47,7 +47,7 @@ cytoscnpy mcp-server
 
 ```powershell
 # Install
-irm https://raw.githubusercontent.com/djinn09/CytoScnPy/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/djinn-soul/CytoScnPy/main/install.ps1 | iex
 
 # Start MCP server (after restarting terminal)
 cytoscnpy mcp-server
@@ -102,7 +102,7 @@ The VS Code extension automatically registers the MCP server. Just install the e
 
 | Tool                    | Description                                       | Parameters                                                               |
 | ----------------------- | ------------------------------------------------- | ------------------------------------------------------------------------ |
-| `analyze_path`          | Full analysis on files/directories                | `path`, `scan_secrets`, `scan_danger`, `check_quality`, `taint_analysis` |
+| `analyze_path`          | Full analysis on files/directories                | `path`, `scan_secrets`, `scan_danger`, `check_quality`                    |
 | `analyze_code`          | Analyze code snippet directly                     | `code`, `filename`                                                       |
 | `quick_scan`            | Fast security scan (secrets & dangerous patterns) | `path`                                                                   |
 | `cyclomatic_complexity` | Calculate complexity metrics                      | `path`                                                                   |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,8 +6,9 @@ Thank you for your interest in contributing to CytoScnPy!
 
 - **Rust**: Version 1.70 or higher.
 - **Cargo**: Comes with Rust.
-- **Python**: Version 3.8 or higher.
-- **Maturin**: `pip install maturin`
+- **Python**: Version 3.10 or higher.
+- **UV or pip**: For Python dependency management.
+- **Maturin**: Included in the dev environment, or install manually with `pip install maturin`.
 
 ## Setup Development Environment
 
@@ -29,8 +30,8 @@ Thank you for your interest in contributing to CytoScnPy!
 3. **Install Dependencies & Build:**
 
    ```bash
-   pip install maturin
-   maturin develop -m cytoscnpy/Cargo.toml
+   uv sync --group dev --group docs
+   uv run maturin develop -m cytoscnpy/Cargo.toml
    ```
 
 4. **Install the docs generator:**
@@ -45,7 +46,7 @@ Thank you for your interest in contributing to CytoScnPy!
 
    ```bash
    cargo test
-   pytest python/tests
+   uv run pytest python/tests
    ```
 
 ## Development Workflow
@@ -59,7 +60,7 @@ Thank you for your interest in contributing to CytoScnPy!
 
 3. **Test:**
    - `cargo test` (Rust unit tests)
-   - `pytest` (Python integration tests)
+   - `uv run pytest python/tests` (Python integration tests)
 
 4. **Submit PR:**
    - Push to your fork.
@@ -70,7 +71,7 @@ Thank you for your interest in contributing to CytoScnPy!
 - `cytoscnpy/` - Rust core library & analysis engine.
 - `python/` - Python wrapper & CLI entry point.
 - `editors/vscode/` - VS Code extension.
-- `cytoscnpy-mcp/` - MCP server documentation.
+- `cytoscnpy-mcp/` - MCP server implementation.
 
 ## Testing
 
@@ -84,4 +85,4 @@ cargo test
 cargo test test_name
 ```
 
-See [tests/README.md](https://github.com/djinn09/CytoScnPy/tree/main/cytoscnpy/tests) for detailed testing guide.
+See [tests/README.md](https://github.com/djinn-soul/CytoScnPy/tree/main/cytoscnpy/tests) for detailed testing guide.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 **High-Performance Python Static Analysis Tool Powered by Rust**
 
-[![CI](https://github.com/djinn09/CytoScnPy/actions/workflows/ci.yml/badge.svg)](https://github.com/djinn09/CytoScnPy/actions/workflows/ci.yml)
+[![CI](https://github.com/djinn-soul/CytoScnPy/actions/workflows/ci.yml/badge.svg)](https://github.com/djinn-soul/CytoScnPy/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/cytoscnpy)](https://pypi.org/project/cytoscnpy/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
@@ -31,14 +31,14 @@ CytoScnPy is a blazing fast static analysis tool for Python codebases. It uses a
 
 ```bash
 # Install
-curl -fsSL https://raw.githubusercontent.com/djinn09/CytoScnPy/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/djinn-soul/CytoScnPy/main/install.sh | bash
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
 # Install
-irm https://raw.githubusercontent.com/djinn09/CytoScnPy/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/djinn-soul/CytoScnPy/main/install.ps1 | iex
 ```
 
 **Via Pip:**
@@ -50,10 +50,12 @@ pip install cytoscnpy
 **From Source:**
 
 ```bash
-git clone https://github.com/djinn09/CytoScnPy.git
+git clone https://github.com/djinn-soul/CytoScnPy.git
 cd CytoScnPy
 maturin develop -m cytoscnpy/Cargo.toml
 ```
+
+> Note: The Python package installs the analysis CLI, but `cytoscnpy mcp-server` is available through the standalone CLI binary (`cytoscnpy-cli` / install script flow), not the Python package entry point.
 
 ---
 
@@ -85,4 +87,4 @@ cytoscnpy . --fix --apply # Apply changes
 - **Documentation**: [djinn09.github.io/CytoScnPy](https://djinn09.github.io/CytoScnPy/)
 - **PyPI**: [pypi.org/project/cytoscnpy](https://pypi.org/project/cytoscnpy/)
 - **VS Code Extension**: [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=djinn09.cytoscnpy)
-- **GitHub Repository**: [github.com/djinn09/CytoScnPy](https://github.com/djinn09/CytoScnPy/)
+- **GitHub Repository**: [github.com/djinn-soul/CytoScnPy](https://github.com/djinn-soul/CytoScnPy/)

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -14,8 +14,8 @@ CytoScnPy provides several pre-commit hooks to automate code analysis in your lo
 
     ```yaml
     repos:
-      - repo: https://github.com/djinn09/CytoScnPy
-        rev: v1.2.1 # Use the latest release tag
+      - repo: https://github.com/djinn-soul/CytoScnPy
+        rev: v1.2.21 # Example: pin the current release tag
         hooks:
           - id: cytoscnpy-check
             # Optional: custom arguments

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,7 +3,7 @@
 > **Architecture:** Hybrid PyO3 + Standalone CLI
 > **Status:** Production-ready core, active development
 
-For completed features and implementation history, see [GitHub Releases](https://github.com/djinn09/CytoScnPy/releases).
+For completed features and implementation history, see [GitHub Releases](https://github.com/djinn-soul/CytoScnPy/releases).
 
 ---
 
@@ -30,7 +30,7 @@ The sections below highlight the work that is still active:
 
 - **Phase 5.7 (Radon Parity Gaps)** – The parity tests around module-level complexity, `else` clauses on loops/try, wildcard matching, and Halstead/raw metrics are in place, but the analyzer logic still needs to be implemented (see the `### 5.7` section below).
 - **Phase 6 (Editor Integration)** – The VS Code extension and accompanying code audit continue to evolve; Phase 6.1 and 6.2 list the UX, command, and bundling gaps that remain.
-- **Phase 6.x (Editor Client Flag)** – Implement `--client` (currently only `vscode`). In the future we may need other editor clients, so keep room to extend behavior safely.
+- **Phase 6.x (Editor Client Expansion)** – `--client vscode` is already shipped. Future work is extending the client model safely if additional editors need client-specific behavior.
 - **Phase 7.6 (Accuracy Improvements)** – The benchmark (F1 = 0.72) and the remaining false positives/negatives (34/60 items) are being chipped away in the dedicated Phase 7.6 subsection.
 
 ### 5.7 Radon Parity Gaps IN PROGRESS
@@ -109,7 +109,7 @@ cargo test --features cfg
 
 ## <a id="phase-6"></a>Phase 6: Editor Integration ✅ DONE
 
-### 6.1 VS Code Extension IN PROGRESS
+### 6.1 VS Code Extension SHIPPED
 
 ### 6.2 Extension Code Audit (Pending Fixes) IN PROGRESS
 
@@ -127,8 +127,8 @@ _Fields in CLI JSON output not captured by `analyzer.ts`:_
 
 #### 6.2.5 Path Handling ✅
 
-- [ ] Add macOS (`cytoscnpy-cli-darwin`) binary bundling
-- [ ] Add Linux (`cytoscnpy-cli-linux`) binary bundling
+- [x] Dedicated VS Code binary workflows build Linux, Windows, macOS x64, and macOS ARM64 artifacts.
+- [ ] Align binary naming across the extension runtime and every release/publish workflow so packaging uses one canonical filename set everywhere.
 
 #### 6.2.6 UX Enhancements
 
@@ -138,7 +138,7 @@ _Fields in CLI JSON output not captured by `analyzer.ts`:_
 | Sidebar Badge      | Show issue count in Explorer sidebar       | Medium   | ✅     |
 | Quick Fixes        | Code actions to remove/comment unused code | High     | ✅     |
 | Gutter Decorations | Visual icons for severity levels           | Low      | ✅     |
-| Progress Indicator | Show progress during workspace analysis    | Medium   | ❌     |
+| Progress Indicator | Show progress during workspace analysis    | Medium   | ✅     |
 | File Caching       | Skip re-analyzing unchanged files          | Low      | ✅     |
 | Problem Grouping   | Better categorization in Problems panel    | Low      | ✅     |
 
@@ -342,11 +342,11 @@ _Tools to improve the workflow around CytoScnPy._
   - Implement a real-time LSP server for VS Code, Neovim, and Zed.
   - Provide instant diagnostics without saving or running CLI.
 
-- [ ] **Config File Support for Notebook Options**
-  - Allow `include_ipynb` and `ipynb_cells` in `.cytoscnpy.toml` and `pyproject.toml`
-  - Currently these are CLI-only flags (`--include-ipynb`, `--ipynb-cells`)
-  - **Rationale:** Enable persistent configuration without passing flags on every run
-  - **Implementation:** Add fields to `CytoScnPyConfig` struct in `src/config.rs`
+- [ ] **Config File Support for Notebook Cell Reporting**
+  - `include_ipynb` is already supported in `.cytoscnpy.toml` / `pyproject.toml`.
+  - `ipynb_cells` is still CLI-only (`--ipynb-cells`).
+  - **Rationale:** Enable persistent notebook cell-level reporting without passing flags on every run.
+  - **Implementation:** Add `ipynb_cells` config support alongside the existing notebook config fields.
 
 - [ ] **Git Integration**
   - **Blame Analysis:** Identify who introduced unused code.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,14 +29,14 @@ CytoScnPy statically analyzes your code to find unused symbols. It detects:
 
 ```bash
 # Install
-curl -fsSL https://raw.githubusercontent.com/djinn09/CytoScnPy/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/djinn-soul/CytoScnPy/main/install.sh | bash
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
 # Install
-irm https://raw.githubusercontent.com/djinn09/CytoScnPy/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/djinn-soul/CytoScnPy/main/install.ps1 | iex
 ```
 
 **Framework Support**: Automatically detects usage in Flask routes, Django views, FastAPI endpoints, and Pydantic models.
@@ -58,7 +58,7 @@ Enable with `--quality`.
 - **Maintainability Index (MI)**: 0-100 score (higher is better).
 - **Halstead Metrics**: Algorithmic complexity.
 
-For a full list of quality rules and their standard IDs (B006, E722, etc.), see the **[Code Quality Rules](quality.md)** reference.
+For a full list of quality rules and their CytoScnPy rule IDs (`CSP-L001`, `CSP-Q301`, etc.), see the **[Code Quality Rules](quality.md)** reference.
 Per-rule pages are available across Best Practices, Maintainability, and Performance categories.
 
 ### Rule Index
@@ -549,4 +549,4 @@ Starts the Model Context Protocol (MCP) server for integration with AI assistant
 
 - **PyPI**: [pypi.org/project/cytoscnpy](https://pypi.org/project/cytoscnpy/)
 - **VS Code Extension**: [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=djinn09.cytoscnpy)
-- **GitHub Repository**: [github.com/djinn09/CytoScnPy](https://github.com/djinn09/CytoScnPy/)
+- **GitHub Repository**: [github.com/djinn-soul/CytoScnPy](https://github.com/djinn-soul/CytoScnPy/)

--- a/editors/vscode/cytoscnpy/README.md
+++ b/editors/vscode/cytoscnpy/README.md
@@ -21,8 +21,8 @@ This extension requires the `cytoscnpy` CLI tool to be available.
 The extension comes with pre-compiled binaries for:
 
 - **Windows**: `cytoscnpy-cli-win32.exe`
-- **Linux**: `cytoscnpy-cli-linux-x64`
-- **macOS**: `cytoscnpy-cli-darwin` (x64) and `cytoscnpy-cli-darwin-arm64` (Apple Silicon)
+- **Linux**: `cytoscnpy-cli-linux`
+- **macOS**: `cytoscnpy-cli-darwin`
 
 The appropriate binary is automatically selected based on your platform.
 
@@ -100,7 +100,7 @@ Simply ask Copilot to use CytoScnPy:
 
 ## Links
 
-- **Documentation**: [djinn-soul.github.io/CytoScnPy](https://djinn-soul.github.io/CytoScnPy/)
+- **Documentation**: [djinn09.github.io/CytoScnPy](https://djinn09.github.io/CytoScnPy/)
 - **PyPI**: [pypi.org/project/cytoscnpy](https://pypi.org/project/cytoscnpy/)
 - **VS Code Extension**: [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=djinn09.cytoscnpy)
 - **GitHub Repository**: [github.com/djinn-soul/CytoScnPy](https://github.com/djinn-soul/CytoScnPy/)


### PR DESCRIPTION
Update readme and doc files to reflect the new repository organization, Python requirements, and placeholders:

- Synchronize all GitHub URLs from djinn09 to the djinn-soul organization.
- Bump the required Python version to ≥3.10 in CONTRIBUTING.md and docs/contributing.md.
- Replace hard‑coded version strings in the VS Code extension output (<version>) and elsewhere with the placeholder.
- Update the install script URLs for macOS, Linux, and Windows to point to the new repo.
- Modify the MCP server CLI examples to use the correct command syntax.
- Adjust binary names in the VS Code extension README (cytoscnpy-cli-linux and cytoscnpy-cli-darwin).
- Update documentation for usage, pre‑commit, and index pages with correct URLs and command snippets.

No breaking changes introduced.