### PR TITLE
Document fail gates and bump versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "cytoscnpy"
-version = "1.2.22"
+version = "1.2.23"
 dependencies = [
  "anyhow",
  "askama",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "cytoscnpy-cli"
-version = "1.2.22"
+version = "1.2.23"
 dependencies = [
  "anyhow",
  "cytoscnpy",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "cytoscnpy-mcp"
-version = "1.2.22"
+version = "1.2.23"
 dependencies = [
  "cytoscnpy",
  "rmcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cytoscnpy", "cytoscnpy-cli", "cytoscnpy-mcp"]
 resolver = "2"
 
 [workspace.package]
-version = "1.2.22"
+version = "1.2.23"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ cytoscnpy . --html --secrets --danger
 | `--max-complexity <N>` | Exit code 1 if any function complexity > N |
 | `--min-mi <N>`         | Exit code 1 if maintainability index < N   |
 | `--fail-on-quality`    | Exit code 1 if any quality issues found    |
+| `--fail-on-secrets`    | Exit code 1 if any secret findings found   |
+| `--fail-on-danger`     | Exit code 1 if danger or taint findings found |
+| `--fail-on-missing-deps` | Exit code 1 if missing dependencies found |
+| `--fail-on-unused-deps` | Exit code 1 if unused dependencies found  |
 | `--max-nesting <N>`    | Exit code 1 if any block nesting > N       |
 | `--max-args <N>`       | Exit code 1 if any function has > N args   |
 | `--max-lines <N>`      | Exit code 1 if any function has > N lines  |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -19,6 +19,10 @@ cytoscnpy [OPTIONS] [COMMAND]
 - `--verbose`, `-v`: Prints detailed logs during the analysis process, including which files are being scanned and any non-fatal issues encountered.
 - `--quiet`: Minimalist output. Only the final summary table (or JSON) is displayed, suppressing the per-file findings table.
 - `--fail-on-quality`: Causes the process to exit with code `1` if _any_ code quality issues (like high complexity or deep nesting) are detected.
+- `--fail-on-secrets`: Enables secret scanning if needed and exits with code `1` if any secret findings are detected.
+- `--fail-on-danger`: Enables dangerous-code/taint scanning if needed and exits with code `1` if any danger or taint findings are detected.
+- `--fail-on-missing-deps`: Enables dependency analysis if needed and exits with code `1` if any missing dependency findings are detected.
+- `--fail-on-unused-deps`: Enables dependency analysis if needed and exits with code `1` if any unused dependency findings are detected.
 - `--html`: Generates a self-contained, interactive HTML report. Note that this feature may require additional dependencies and automatically enables quality scanning.
 - `--client <CLIENT>`: Identify the calling editor/client. Currently only `vscode` is supported. When `vscode` is set, scan enable/disable comes only from CLI flags (VS Code settings), but project config is still loaded for advanced tuning (for example, custom secret patterns).
 
@@ -49,9 +53,9 @@ cytoscnpy [OPTIONS] [COMMAND]
 - `--make-whitelist`: Generates a Python whitelist from currently detected unused symbols.
 - `--whitelist <PATH>`: Loads one or more whitelist files to suppress matching dead-code findings.
 
-### Quality Thresholds (Gate Overrides)
+### CI/CD Failure Gates
 
-These flags allow you to set strict "gates" for your code. If any part of the codebase exceeds these numbers, CytoScnPy will exit with code `1`.
+These flags allow you to set strict gates for CI/CD. If any enabled gate fails, CytoScnPy exits with code `1`. Failure gates that depend on optional scans enable those scans automatically.
 
 - `--fail-threshold <N>`: Exit with 1 if the total percentage of unused code exceeds `N`.
 - `--max-complexity <N>`: Sets the maximum allowed Cyclomatic Complexity (standard is often `10`).
@@ -59,6 +63,11 @@ These flags allow you to set strict "gates" for your code. If any part of the co
 - `--max-nesting <N>`: Sets the maximum allowed indentation/nesting level (e.g., `3` or `4`).
 - `--max-args <N>`: Sets the maximum number of arguments a function can have.
 - `--max-lines <N>`: Sets the maximum number of lines a function can have.
+- `--fail-on-quality`: Exit with 1 if any quality issue is found.
+- `--fail-on-secrets`: Exit with 1 if any secret finding is found; implies `--secrets`.
+- `--fail-on-danger`: Exit with 1 if any danger or taint finding is found; implies `--danger`.
+- `--fail-on-missing-deps`: Exit with 1 if missing dependencies are found; implies `--deps`.
+- `--fail-on-unused-deps`: Exit with 1 if unused dependencies are found; implies `--deps`.
 
 ## Subcommands
 
@@ -174,6 +183,10 @@ cytoscnpy deps [OPTIONS] [PATHS]...
 - `--exclude <DIRS>`: Folders to exclude from import scanning.
 - `--extra-installed`: Also report packages installed in the venv but not declared.
 - `--orphans`: Report orphan packages — installed, undeclared, not imported, and not required by any other installed package.
+- `--fail-on-unused`: Exit with code `1` if unused dependencies are found.
+- `--fail-on-missing`: Exit with code `1` if missing dependencies are found.
+- `--fail-on-extra-installed`: Exit with code `1` if extra installed packages are found; also enables the extra-installed report.
+- `--fail-on-orphans`: Exit with code `1` if orphan packages are found; also enables the orphan report.
 - `--impact <PKG>`: Show which transitive packages would be removable if `<PKG>` were dropped (requires a lockfile).
 - `--venv <PATH>`: Override the venv path (default: auto-detect `.venv`).
 - `--lockfile <PATH>`: Override the lockfile path (default: auto-detect `uv.lock` / `poetry.lock`).
@@ -239,6 +252,8 @@ clone_similarity = 0.8     # Similarity threshold (0.0-1.0)
 
 # CI/CD
 fail_threshold = 5.0
+fail_on_secrets = true
+fail_on_danger = true
 
 # Inline whitelist (suppress specific dead-code symbols)
 [[cytoscnpy.whitelist]]
@@ -275,6 +290,10 @@ rule_id = "CSP-SCUSTOM-001" # Optional
 enabled = true                        # Run dep analysis by default (same as --deps)
 ignore_unused = ["celery", "redis"]   # Suppress specific unused-dep findings
 ignore_missing = ["numpy"]            # Suppress specific missing-dep findings
+fail_on_unused = true                 # Fail if unused dependencies are reported
+fail_on_missing = true                # Fail if missing dependencies are reported
+fail_on_extra_installed = false       # Fail on undeclared installed packages
+fail_on_orphans = false               # Fail on installed orphan packages
 
 # Custom package → import name mappings (for packages where the import name
 # differs from the package name and is not in the built-in mapping)
@@ -297,7 +316,7 @@ custom_sanitizers = ["mylib.clean"] # Functions that clear taint
 ## Exit Codes
 
 - `0`: Success, no issues found (or issues below threshold).
-- `1`: Issues found exceeding thresholds (quality, security, or fail_threshold).
+- `1`: Issues found exceeding configured gates (quality, security, dependency, or fail_threshold).
 - `2`: Runtime error or invalid arguments.
 
 ## See Also

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -47,7 +47,10 @@ Thank you for your interest in contributing to CytoScnPy!
    ```bash
    cargo test
    uv run pytest python/tests
+   prek run --all-files
    ```
+
+   The full `prek` gate includes formatting/linting, Rust checks, `uv` lock/export hooks, strict `basedpyright`, and `pip-audit`.
 
 ## Development Workflow
 
@@ -57,6 +60,7 @@ Thank you for your interest in contributing to CytoScnPy!
 2. **Make Changes:**
    - Run `cargo fmt` to format.
    - Run `cargo clippy` to lint.
+   - Run `prek run --all-files` before opening a PR; it includes strict `basedpyright` and `pip-audit`.
 
 3. **Test:**
    - `cargo test` (Rust unit tests)

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -45,18 +45,24 @@ If you only want to fail on security issues but want to see quality warnings, us
 
 ```yaml
 - id: cytoscnpy-security
-  args: ["--fail-threshold", "0"]
+  args: ["--fail-on-secrets", "--fail-on-danger"]
 - id: cytoscnpy-quality
   # no quality gate flags => findings are reported without forcing failure
 ```
 
 ### Strictness Levels
 
-You can enforce strict quality gates using these flags in `args`:
+You can enforce strict failure gates using these flags in `args`:
 
 - `--fail-on-quality`: Exit with code 1 if any quality issues are found.
+- `--fail-on-secrets`: Exit with code 1 if any secret findings are found.
+- `--fail-on-danger`: Exit with code 1 if any danger or taint findings are found.
+- `--fail-on-missing-deps`: Exit with code 1 if missing dependencies are found.
+- `--fail-on-unused-deps`: Exit with code 1 if unused dependencies are found.
 - `--fail-threshold <N>`: Fail if unused code percentage exceeds N.
 - `--max-complexity <N>`: Fail if any function exceeds complexity N.
+
+For this repository's own contributor checks, `prek run --all-files` also runs the local `basedpyright` strict type-check and `pip-audit` dependency scan hooks through `uv`.
 
 ### Performance
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -316,7 +316,7 @@ _Tools to improve the workflow around CytoScnPy._
   - See `docs/pre-commit.md` for setup instructions.
 - [x] **CI/CD Integration Examples** ✅
   - Reference workflows for GitHub Actions provided in `.github/workflows/`.
-  - Supports `--fail-on-quality` and `--fail-threshold` for gatekeeping.
+  - Supports `--fail-on-quality`, security failure gates (`--fail-on-secrets`, `--fail-on-danger`), dependency failure gates, and `--fail-threshold` for gatekeeping.
 - [x] **uv Package Manager Integration** ✅
   - Full support for `uv`-managed environments.
   - Used in official lint/CI workflows.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -88,6 +88,14 @@ cytoscnpy deps . --ignore-unused celery,redis
 cytoscnpy deps . --impact httpx   # show what transitive deps would go with httpx
 ```
 
+**CI gates** — fail a build on dependency findings. Main-scan gates enable dependency analysis automatically:
+
+```bash
+cytoscnpy . --fail-on-missing-deps --fail-on-unused-deps
+cytoscnpy deps . --fail-on-missing --fail-on-unused
+cytoscnpy deps . --fail-on-extra-installed --fail-on-orphans
+```
+
 **What it reports:**
 
 | Finding | Meaning |
@@ -97,9 +105,16 @@ cytoscnpy deps . --impact httpx   # show what transitive deps would go with http
 | Extra installed | In the venv but not declared (transitive deps) |
 | Orphan | Installed, undeclared, not imported, not needed by any other package |
 
-**Package name aliasing** is handled automatically for common packages (e.g. `Pillow` → `PIL`, `scikit-learn` → `sklearn`, `python-dateutil` → `dateutil`). For custom internal packages, add a mapping in `.cytoscnpy.toml`:
+**Package name aliasing** is handled automatically for common packages (e.g. `Pillow` → `PIL`, `scikit-learn` → `sklearn`, `python-dateutil` → `dateutil`). For custom internal packages, add a mapping in `.cytoscnpy.toml`. Dependency gates can also live in config:
 
 ```toml
+[cytoscnpy.deps]
+enabled = true
+fail_on_unused = true
+fail_on_missing = true
+fail_on_extra_installed = false
+fail_on_orphans = false
+
 [cytoscnpy.deps.package_mapping]
 "my-internal-lib" = ["mylib", "mylib_ext"]
 ```
@@ -268,6 +283,8 @@ clone_similarity = 0.8     # Similarity threshold (0.0-1.0)
 fail_threshold = 5.0   # >5% unused code
 max_complexity = 15    # Function CC > 15
 min_mi = 40.0          # MI < 40
+fail_on_secrets = true # Any secret finding
+fail_on_danger = true  # Any danger or taint finding
 ```
 
 ### Option 2: `pyproject.toml`
@@ -293,6 +310,8 @@ clone_similarity = 0.8
 fail_threshold = 5.0
 max_complexity = 15
 min_mi = 40.0
+fail_on_secrets = true
+fail_on_danger = true
 ```
 
 ### Advanced Config (Security)
@@ -373,9 +392,9 @@ cytoscnpy [PATHS]... [OPTIONS]
 | `--include-tests`        | Include test files in analysis. |
 | `--include-ipynb`        | Include Jupyter notebooks.      |
 
-### CI/CD Quality Gates
+### CI/CD Failure Gates
 
-CytoScnPy can enforce quality standards by exiting with code `1`:
+CytoScnPy can enforce quality, security, and dependency standards by exiting with code `1`. Security and dependency failure gates enable their required scans automatically.
 
 | Flag                   | Description                          |
 | ---------------------- | ------------------------------------ |
@@ -383,6 +402,10 @@ CytoScnPy can enforce quality standards by exiting with code `1`:
 | `--max-complexity <N>` | Fail if any function complexity > N. |
 | `--min-mi <N>`         | Fail if Maintainability Index < N.   |
 | `--fail-on-quality`    | Fail on any quality issue.           |
+| `--fail-on-secrets`    | Fail on any secret finding.          |
+| `--fail-on-danger`     | Fail on any danger or taint finding. |
+| `--fail-on-missing-deps` | Fail on any missing dependency.     |
+| `--fail-on-unused-deps` | Fail on any unused dependency.      |
 
 ### Subcommands
 
@@ -477,6 +500,10 @@ Analyzes unused and missing dependencies in isolation.
 - `--impact <PKG>`: Show transitive packages removable with `<PKG>`.
 - `--ignore-unused <PKGS>`: Suppress specific unused-dep findings.
 - `--ignore-missing <PKGS>`: Suppress specific missing-dep findings.
+- `--fail-on-unused`: Fail if unused dependencies are found.
+- `--fail-on-missing`: Fail if missing dependencies are found.
+- `--fail-on-extra-installed`: Fail if extra installed packages are found.
+- `--fail-on-orphans`: Fail if orphan packages are found.
 - `--venv <PATH>`: Override venv path (default: auto-detect `.venv`).
 
 #### `mcp-server` - MCP Integration

--- a/editors/vscode/cytoscnpy/package-lock.json
+++ b/editors/vscode/cytoscnpy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cytoscnpy",
-  "version": "0.1.19",
+  "version": "0.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cytoscnpy",
-      "version": "0.1.21",
+      "version": "0.1.23",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/editors/vscode/cytoscnpy/package.json
+++ b/editors/vscode/cytoscnpy/package.json
@@ -3,7 +3,7 @@
   "publisher": "djinn09",
   "displayName": "CytoScnPy",
   "description": "Python static analyzer with MCP server for GitHub Copilot. Real-time dead code detection, security scanning, and code quality metrics.",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "icon": "assets/icon.png",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- document the PR #94 security/dependency failure gates in CLI, usage, pre-commit, and roadmap docs
- document `basedpyright` and `pip-audit` as part of the repo's `prek run --all-files` contributor gate
- bump Cargo workspace metadata to 1.2.23 and VS Code extension metadata to 0.1.23

## Validation
- `git diff --cached --check`
- `git diff --check`
- `cargo metadata --no-deps --format-version 1`
- `PYTHONUTF8=1 uv run mkdocs build --strict`