### PR TITLE
fix(visitor): correctly identify methods using scope stack

### DIFF
--- a/cytoscnpy/src/visitor/function_def_meta.rs
+++ b/cytoscnpy/src/visitor/function_def_meta.rs
@@ -1,4 +1,4 @@
-use super::{CytoScnPyVisitor, DefinitionInfo, DefinitionType, SmallVec};
+use super::{CytoScnPyVisitor, DefinitionInfo, DefinitionType, ScopeType, SmallVec};
 
 impl CytoScnPyVisitor<'_> {
     pub(super) fn register_function_definition(
@@ -8,10 +8,14 @@ impl CytoScnPyVisitor<'_> {
     ) -> String {
         let name = name_node.id.as_str();
         let qualified_name = self.get_qualified_name(name);
-        let def_type = if self.class_stack.is_empty() {
-            DefinitionType::Function
-        } else {
+        let def_type = if self
+            .scope_stack
+            .last()
+            .is_some_and(|scope| matches!(scope.kind, ScopeType::Class(_)))
+        {
             DefinitionType::Method
+        } else {
+            DefinitionType::Function
         };
 
         let def_range = name_node.range;

--- a/cytoscnpy/tests/unreachable_nested_regression_test.rs
+++ b/cytoscnpy/tests/unreachable_nested_regression_test.rs
@@ -55,3 +55,55 @@ def outer():
         "Nested local helper should not be escalated as unreachable finding"
     );
 }
+
+#[test]
+fn test_method_nested_local_function_call_is_counted_as_usage() {
+    let dir = project_tempdir();
+    let file_path = dir.path().join("nested_in_method.py");
+    let mut file = File::create(&file_path).unwrap();
+
+    writeln!(
+        file,
+        r#"
+class Processor:
+    def transform(self, value):
+        def normalize(item):
+            return item.strip().lower()
+
+        def unused_local(item):
+            return item.upper()
+
+        return normalize(value)
+
+processor = Processor()
+print(processor.transform(" Example "))
+"#
+    )
+    .unwrap();
+
+    let mut analyzer = CytoScnPy::default().with_confidence(60).with_tests(false);
+    let result = analyzer.analyze(dir.path());
+
+    let unused_function_names: Vec<_> = result
+        .unused_functions
+        .iter()
+        .map(|d| d.full_name.as_str())
+        .collect();
+    let unused_method_names: Vec<_> = result
+        .unused_methods
+        .iter()
+        .map(|d| d.full_name.as_str())
+        .collect();
+    assert!(
+        !unused_function_names.contains(&"nested_in_method.Processor.transform.normalize"),
+        "Called local helper inside method should not be reported unused; got: {unused_function_names:?}"
+    );
+    assert!(
+        !unused_method_names.contains(&"nested_in_method.Processor.transform.normalize"),
+        "Called local helper inside method should not be reported as an unused method; got: {unused_method_names:?}"
+    );
+    assert!(
+        unused_function_names.contains(&"nested_in_method.Processor.transform.unused_local"),
+        "Unused local helper inside method should still be reported; got: {unused_function_names:?}"
+    );
+}


### PR DESCRIPTION
Update 
egister_function_definition to determine if a definition is a method by checking if the current scope is a class, rather than relying on the class stack being non-empty. This ensures that nested functions within methods are correctly categorized and analyzed.

Also add a regression test to verify that local functions within a method are correctly identified as used or unused based on their actual usage.