### PR TITLE
fix(deps): resolve import names from evidence, not guesswork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.13"]
+        python-version: ["3.10", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -182,3 +182,9 @@ jobs:
           else
             maturin build --release --all-features --out dist -i python
           fi
+
+      - name: Install and import wheel
+        shell: bash
+        run: |
+          python -m pip install --force-reinstall dist/*.whl
+          python -c "import cytoscnpy"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,18 +30,6 @@ jobs:
           fail-on-scopes: runtime
           # Comment on PR with vulnerability summary
           comment-summary-in-pr: always
-          # Allow known unavailable vulnerabilities for Python 3.8 support:
-          # setuptools path traversal, urllib3 redirect/proxy/decompression/streaming DoS,
-          # filelock TOCTOU, pip path traversal (all require Py 3.9+ to fix)
-          allow-ghsas: >-
-            GHSA-5rjg-fvgr-3xxf,
-            GHSA-g4mx-q9vg-27p4,
-            GHSA-34jh-p97f-mpxf,
-            GHSA-gm62-xv2j-4w53,
-            GHSA-2xpw-w6gg-jr37,
-            GHSA-pw2r-r8wx-5mcc,
-            GHSA-4xh5-x5gv-qwph
-
           # License check - allow common permissive licenses
           allow-licenses: >-
             MIT,

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,9 +9,12 @@ on:
       - "cytoscnpy-mcp/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "deny.toml"
       - ".github/workflows/security.yml"
   push:
     branches: ["main"]
+  schedule:
+    - cron: "37 3 * * 1"
   workflow_dispatch:
 
 concurrency:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "cytoscnpy"
-version = "1.2.25"
+version = "1.2.26"
 dependencies = [
  "anyhow",
  "askama",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "cytoscnpy-cli"
-version = "1.2.25"
+version = "1.2.26"
 dependencies = [
  "anyhow",
  "cytoscnpy",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "cytoscnpy-mcp"
-version = "1.2.25"
+version = "1.2.26"
 dependencies = [
  "cytoscnpy",
  "rmcp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,17 +1022,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
-name = "mio"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "nbformat"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,15 +1689,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,16 +1711,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
 
 [[package]]
 name = "static_assertions"
@@ -1858,14 +1828,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
  "bytes",
- "libc",
- "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
- "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2235,16 +2199,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2262,31 +2217,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2296,22 +2234,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2320,22 +2246,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2344,22 +2258,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2368,22 +2270,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cytoscnpy", "cytoscnpy-cli", "cytoscnpy-mcp"]
 resolver = "2"
 
 [workspace.package]
-version = "1.2.25"
+version = "1.2.26"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -7,4 +7,3 @@ ruff==0.15.6
 dead==2.1.0
 skylos==4.0.0
 deadcode==2.4.1
-pylint==4.0.4

--- a/cytoscnpy-cli/Cargo.toml
+++ b/cytoscnpy-cli/Cargo.toml
@@ -5,10 +5,10 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-cytoscnpy = { path = "../cytoscnpy" }                                # use library crate
+cytoscnpy = { path = "../cytoscnpy", default-features = false }      # use library crate
 cytoscnpy-mcp = { path = "../cytoscnpy-mcp" }                        # MCP server integration
 anyhow = "1.0"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["io-std", "rt-multi-thread"] }
 rmcp = { version = "1.7.0", features = ["server", "transport-io"] }
 
 # Inherit lints from workspace
@@ -16,7 +16,8 @@ rmcp = { version = "1.7.0", features = ["server", "transport-io"] }
 workspace = true
 
 [features]
-default = ["cst", "html_report"]
+default = ["cst", "html_report", "cfg"]
 cst = ["cytoscnpy/cst"]
 html_report = ["cytoscnpy/html_report"]
+cfg = ["cytoscnpy/cfg"]
 heap-profile = ["cytoscnpy/heap-profile"]

--- a/cytoscnpy-mcp/Cargo.toml
+++ b/cytoscnpy-mcp/Cargo.toml
@@ -10,7 +10,7 @@ name = "cytoscnpy_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-cytoscnpy = { path = "../cytoscnpy" }
+cytoscnpy = { path = "../cytoscnpy", default-features = false }
 rmcp = { version = "1.7.0", features = ["server", "transport-io"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/cytoscnpy/Cargo.toml
+++ b/cytoscnpy/Cargo.toml
@@ -54,6 +54,7 @@ serde_json = { version = "1.0", features = [
 nbformat = "1.2"
 regex = { version = "1.10", default-features = false, features = [
     "std",
+    "unicode-case",
     "unicode-perl",
     "perf",
 ] }

--- a/cytoscnpy/src/cli.rs
+++ b/cytoscnpy/src/cli.rs
@@ -68,7 +68,9 @@ CONFIGURATION FILE
   # ignore = [\"CSP-P003\"]
 
   # Silence specific rules only for files matching a glob pattern.
-  # per-file-ignores = { \"tests/*\" = [\"CSP-D701\"] }
+  # Use a table (not inline `{ ... }`) so it can span multiple lines:
+  # [cytoscnpy.per-file-ignores]
+  # \"tests/*\" = [\"CSP-D701\"]
 
   # Detect Type-1/2/3 duplicate code blocks across the project.
   # clones = false
@@ -82,7 +84,7 @@ CONFIGURATION FILE
   Advanced subsections (run `cytoscnpy init` or see docs/CLI.md for full options):
     [cytoscnpy.secrets_config]   entropy tuning, custom patterns
     [cytoscnpy.danger_config]    taint sources/sinks/sanitizers
-    [[cytoscnpy.whitelist]]      inline dead-code suppressions
+    whitelist = [ { name = ... } ]   inline dead-code suppressions (array, one entry per line)
 ";
 
 /// Command line interface configuration using `clap`.

--- a/cytoscnpy/src/clones/detector/cfg_validation.rs
+++ b/cytoscnpy/src/clones/detector/cfg_validation.rs
@@ -1,5 +1,7 @@
 use super::CloneDetector;
+#[cfg(feature = "cfg")]
 use crate::clones::{parser, ClonePair};
+#[cfg(feature = "cfg")]
 use std::path::PathBuf;
 
 impl CloneDetector {

--- a/cytoscnpy/src/commands/clones/findings.rs
+++ b/cytoscnpy/src/commands/clones/findings.rs
@@ -76,9 +76,6 @@ pub fn generate_clone_findings_with_thresholds(
                 #[cfg(not(feature = "cst"))]
                 let _ = inst;
 
-                #[cfg(not(feature = "cst"))]
-                let ctx = ctx;
-
                 let confidence = scorer.score(pair, &ctx);
                 (confidence.score, confidence.decision)
             };

--- a/cytoscnpy/src/commands/deps.rs
+++ b/cytoscnpy/src/commands/deps.rs
@@ -125,7 +125,8 @@ fn write_unused_dependencies<W: Write>(
 fn dependency_source_name(dep: &DeclaredDependency) -> String {
     match &dep.source {
         crate::deps::DependencySource::Pyproject => "pyproject.toml".to_owned(),
-        crate::deps::DependencySource::Requirements(file) => file.clone(),
+        crate::deps::DependencySource::Requirements(file)
+        | crate::deps::DependencySource::Setup(file) => file.clone(),
     }
 }
 

--- a/cytoscnpy/src/commands/init.rs
+++ b/cytoscnpy/src/commands/init.rs
@@ -67,7 +67,11 @@ const DEFAULT_CONFIG: &str = r#"
 # ignore = ["CSP-P003"]
 
 # Silence specific rules only for files matching a glob pattern.
-# per-file-ignores = { "tests/*" = ["CSP-D701"], "**/__init__.py" = ["CSP-L001"] }
+# Use a real table (not an inline `{ ... }`) so it can span multiple lines
+# and hold as many glob -> rule-list entries as you need:
+# [cytoscnpy.per-file-ignores]
+# "tests/*" = ["CSP-D701"]
+# "**/__init__.py" = ["CSP-L001"]
 
 
 # ── Clone detection ───────────────────────────────────────────────────────────
@@ -88,14 +92,13 @@ const DEFAULT_CONFIG: &str = r#"
 # ── Inline whitelist ──────────────────────────────────────────────────────────
 # Suppress specific dead-code symbols without a separate whitelist file.
 # Each entry can target a single name, a wildcard pattern, or a regex.
-
-# [[cytoscnpy.whitelist]]
-# # The symbol name (or pattern) to suppress.
-# name = "my_unused_fn"
-# # Match mode: "exact" (default), "wildcard" (glob-style), or "regex".
-# pattern = "exact"
-# # Optional: restrict this entry to files matching a glob.
-# # file = "src/api/*.py"
+# Add as many entries as you need in one array (each entry stays on its own
+# line; only add commas between entries, not inside one):
+# whitelist = [
+#   { name = "my_unused_fn" },
+#   { name = "test_*", pattern = "wildcard" },
+#   { name = "legacy_handler", file = "src/api/*.py" },
+# ]
 
 
 # ── Secrets scanning (advanced) ───────────────────────────────────────────────
@@ -209,7 +212,11 @@ pub const DEFAULT_PYPROJECT_CONFIG: &str = r#"
 # ignore = ["CSP-P003"]
 
 # Silence specific rules only for files matching a glob pattern.
-# per-file-ignores = { "tests/*" = ["CSP-D701"], "**/__init__.py" = ["CSP-L001"] }
+# Use a real table (not an inline `{ ... }`) so it can span multiple lines
+# and hold as many glob -> rule-list entries as you need:
+# [tool.cytoscnpy.per-file-ignores]
+# "tests/*" = ["CSP-D701"]
+# "**/__init__.py" = ["CSP-L001"]
 
 
 # ── Clone detection ───────────────────────────────────────────────────────────
@@ -230,14 +237,13 @@ pub const DEFAULT_PYPROJECT_CONFIG: &str = r#"
 # ── Inline whitelist ──────────────────────────────────────────────────────────
 # Suppress specific dead-code symbols without a separate whitelist file.
 # Each entry can target a single name, a wildcard pattern, or a regex.
-
-# [[tool.cytoscnpy.whitelist]]
-# # The symbol name (or pattern) to suppress.
-# name = "my_unused_fn"
-# # Match mode: "exact" (default), "wildcard" (glob-style), or "regex".
-# pattern = "exact"
-# # Optional: restrict this entry to files matching a glob.
-# # file = "src/api/*.py"
+# Add as many entries as you need in one array (each entry stays on its own
+# line; only add commas between entries, not inside one):
+# whitelist = [
+#   { name = "my_unused_fn" },
+#   { name = "test_*", pattern = "wildcard" },
+#   { name = "legacy_handler", file = "src/api/*.py" },
+# ]
 
 
 # ── Secrets scanning (advanced) ───────────────────────────────────────────────

--- a/cytoscnpy/src/config/tests.rs
+++ b/cytoscnpy/src/config/tests.rs
@@ -112,3 +112,56 @@ min_mi = 65.0
     let config = Config::load_from_path(&py_file);
     assert_eq!(config.cytoscnpy.min_mi, Some(65.0));
 }
+
+#[test]
+fn test_per_file_ignores_multiline_table_and_multiple_whitelist_blocks() {
+    let dir = TempDir::new().unwrap();
+    let mut file = std::fs::File::create(dir.path().join(".cytoscnpy.toml")).unwrap();
+    writeln!(
+        file,
+        r#"[cytoscnpy]
+confidence = 60
+
+[cytoscnpy.per-file-ignores]
+"tests/*" = ["CSP-D701"]
+"**/__init__.py" = ["CSP-L001"]
+
+[[cytoscnpy.whitelist]]
+name = "my_unused_fn"
+
+[[cytoscnpy.whitelist]]
+name = "another_fn"
+pattern = "wildcard"
+"#
+    )
+    .unwrap();
+
+    let config = Config::load_from_path(dir.path());
+    let ignores = config.cytoscnpy.per_file_ignores.unwrap();
+    assert_eq!(ignores.get("tests/*").unwrap(), &vec!["CSP-D701".to_string()]);
+    assert_eq!(
+        ignores.get("**/__init__.py").unwrap(),
+        &vec!["CSP-L001".to_string()]
+    );
+
+    assert_eq!(config.cytoscnpy.whitelist.len(), 2);
+    assert_eq!(config.cytoscnpy.whitelist[0].name, "my_unused_fn");
+    assert_eq!(config.cytoscnpy.whitelist[1].name, "another_fn");
+}
+
+#[test]
+fn test_whitelist_compact_array_of_inline_tables() {
+    let content = r#"
+[cytoscnpy]
+whitelist = [
+  { name = "fn_one" },
+  { name = "fn_two", pattern = "wildcard" },
+  { name = "fn_three", file = "src/api/*.py" },
+]
+"#;
+    let config = toml::from_str::<Config>(content).unwrap();
+    assert_eq!(config.cytoscnpy.whitelist.len(), 3);
+    assert_eq!(config.cytoscnpy.whitelist[0].name, "fn_one");
+    assert_eq!(config.cytoscnpy.whitelist[1].name, "fn_two");
+    assert_eq!(config.cytoscnpy.whitelist[2].file.as_deref(), Some("src/api/*.py"));
+}

--- a/cytoscnpy/src/config/tests.rs
+++ b/cytoscnpy/src/config/tests.rs
@@ -138,10 +138,13 @@ pattern = "wildcard"
 
     let config = Config::load_from_path(dir.path());
     let ignores = config.cytoscnpy.per_file_ignores.unwrap();
-    assert_eq!(ignores.get("tests/*").unwrap(), &vec!["CSP-D701".to_string()]);
+    assert_eq!(
+        ignores.get("tests/*").unwrap(),
+        &vec!["CSP-D701".to_owned()]
+    );
     assert_eq!(
         ignores.get("**/__init__.py").unwrap(),
-        &vec!["CSP-L001".to_string()]
+        &vec!["CSP-L001".to_owned()]
     );
 
     assert_eq!(config.cytoscnpy.whitelist.len(), 2);
@@ -163,5 +166,8 @@ whitelist = [
     assert_eq!(config.cytoscnpy.whitelist.len(), 3);
     assert_eq!(config.cytoscnpy.whitelist[0].name, "fn_one");
     assert_eq!(config.cytoscnpy.whitelist[1].name, "fn_two");
-    assert_eq!(config.cytoscnpy.whitelist[2].file.as_deref(), Some("src/api/*.py"));
+    assert_eq!(
+        config.cytoscnpy.whitelist[2].file.as_deref(),
+        Some("src/api/*.py")
+    );
 }

--- a/cytoscnpy/src/deps/analysis.rs
+++ b/cytoscnpy/src/deps/analysis.rs
@@ -248,7 +248,12 @@ struct EnvironmentMapping {
 
 fn environment_mapping(installed: &FxHashMap<String, InstalledPackage>) -> EnvironmentMapping {
     let mut mapping = EnvironmentMapping::default();
-    for (normalized, pkg) in installed {
+    // Several distributions can share one import name (namespace packages like
+    // `google`), and the reverse map keeps the first writer. Iterate in sorted
+    // order so the winner does not depend on hash iteration order.
+    let mut packages: Vec<(&String, &InstalledPackage)> = installed.iter().collect();
+    packages.sort_unstable_by_key(|(normalized, _)| *normalized);
+    for (normalized, pkg) in packages {
         if pkg.top_level.is_empty() {
             continue;
         }

--- a/cytoscnpy/src/deps/analysis.rs
+++ b/cytoscnpy/src/deps/analysis.rs
@@ -232,9 +232,36 @@ fn is_local_package(roots: &[PathBuf], module_name: &str) -> bool {
 /// itself.
 struct ImportResolver<'a> {
     custom: Option<&'a FxHashMap<String, Vec<String>>>,
+    /// Import name → normalized distribution name, derived from `custom`.
+    custom_reverse: FxHashMap<String, String>,
     environment: &'a EnvironmentMapping,
     builtin: &'static FxHashMap<&'static str, Vec<&'static str>>,
     builtin_reverse: &'static FxHashMap<&'static str, &'static str>,
+}
+
+/// Inverts the `package_mapping` config so an import can be traced back to the
+/// distribution the user mapped it to. Without this, a configured mapping makes
+/// the declared dependency look used but still leaves the import looking
+/// undeclared. Entries are visited in sorted order so that two distributions
+/// claiming one import name resolve to the same winner on every run.
+fn custom_reverse_mapping(
+    custom: Option<&FxHashMap<String, Vec<String>>>,
+) -> FxHashMap<String, String> {
+    let mut reverse = FxHashMap::default();
+    let Some(custom) = custom else {
+        return reverse;
+    };
+    let mut entries: Vec<(&String, &Vec<String>)> = custom.iter().collect();
+    entries.sort_unstable_by_key(|(dist, _)| *dist);
+    for (dist, import_names) in entries {
+        let normalized = super::declared::normalize_package_name(dist);
+        for import_name in import_names {
+            reverse
+                .entry(import_name.clone())
+                .or_insert_with(|| normalized.clone());
+        }
+    }
+    reverse
 }
 
 /// Import names derived from the packages installed in the virtual environment.
@@ -296,6 +323,13 @@ impl ImportResolver<'_> {
     /// The normalized distribution name an import most likely comes from.
     fn distribution_for(&self, import_name: &str) -> String {
         let import_lower = import_name.to_lowercase();
+        if let Some(dist) = self
+            .custom_reverse
+            .get(import_name)
+            .or_else(|| self.custom_reverse.get(&import_lower))
+        {
+            return dist.clone();
+        }
         if let Some(dist) = self
             .environment
             .reverse
@@ -505,6 +539,12 @@ fn find_transitive_imports(
         if stdlib_modules.contains(import_name.as_str())
             || is_local_package(options.roots, import_name)
         {
+            continue;
+        }
+        // A namespace root (`google`) can resolve to whichever provider the venv
+        // recorded, so it may name a reachable-but-undeclared distribution even
+        // though a declared one publishes into that same namespace.
+        if declared_namespace_matches(&import_name.to_lowercase(), &declared_norm) {
             continue;
         }
         let package_name = resolver.distribution_for(import_name);
@@ -745,6 +785,7 @@ pub fn analyze_dependencies(options: &DepsOptions<'_>) -> DepsResult {
     let environment = environment_mapping(&installed);
     let resolver = ImportResolver {
         custom: options.package_mapping,
+        custom_reverse: custom_reverse_mapping(options.package_mapping),
         environment: &environment,
         builtin: get_package_mapping(),
         builtin_reverse: get_reverse_mapping(),

--- a/cytoscnpy/src/deps/analysis.rs
+++ b/cytoscnpy/src/deps/analysis.rs
@@ -129,8 +129,55 @@ pub struct DepsOptions<'a> {
     pub include_dev_unused: bool,
 }
 
-fn is_local_package(roots: &[PathBuf], module_name: &str) -> bool {
+/// Distribution names that publish into a shared namespace package: the import
+/// root is the first `_`-separated segment of the distribution name
+/// (`google-cloud-storage` → `google`, `ruamel.yaml` → `ruamel`).
+const KNOWN_NAMESPACE_IMPORTS: &[&str] = &[
+    "azure",
+    "backports",
+    "google",
+    "jaraco",
+    "paste",
+    "repoze",
+    "ruamel",
+    "sphinxcontrib",
+    "zc",
+    "zope",
+];
+
+/// True if `dist_normalized` is a distribution published under the namespace
+/// package `import_name` (e.g. `google_cloud_storage` under `google`).
+fn dist_is_in_namespace(dist_normalized: &str, import_name: &str) -> bool {
+    KNOWN_NAMESPACE_IMPORTS.contains(&import_name)
+        && dist_normalized.starts_with(import_name)
+        && dist_normalized.as_bytes().get(import_name.len()) == Some(&b'_')
+}
+
+/// The namespace import root a declared distribution would be imported through,
+/// if it belongs to a known namespace package.
+fn namespace_root_for_dist(dist_normalized: &str) -> Option<&'static str> {
+    KNOWN_NAMESPACE_IMPORTS
+        .iter()
+        .copied()
+        .find(|root| dist_is_in_namespace(dist_normalized, root))
+}
+
+/// Directories a first-party module could live in for a given analysis root.
+/// Covers the flat layout (`<root>/pkg`) and the src layout (`<root>/src/pkg`).
+fn local_search_dirs(roots: &[PathBuf]) -> Vec<PathBuf> {
+    let mut dirs = Vec::with_capacity(roots.len() * 2);
     for root in roots {
+        dirs.push(root.clone());
+        let src = root.join("src");
+        if src.is_dir() {
+            dirs.push(src);
+        }
+    }
+    dirs
+}
+
+fn is_local_package(roots: &[PathBuf], module_name: &str) -> bool {
+    for root in &local_search_dirs(roots) {
         let dir = root.join(module_name);
         if dir.is_dir() {
             // Regular package: explicit init file.
@@ -173,13 +220,102 @@ fn is_local_package(roots: &[PathBuf], module_name: &str) -> bool {
     false
 }
 
+// ── Import name resolution ───────────────────────────────────────────────────
+
+/// Maps between distribution names and the import names they provide.
+///
+/// A distribution's import name frequently differs from its name on `PyPI`
+/// (`pyyaml` → `yaml`), and no static table can cover every distribution. So
+/// evidence is preferred over guesswork, in order: the `package_mapping` config, then
+/// the `top_level.txt` the installer recorded in the virtual environment, then
+/// the built-in table of common mismatches, and only then the distribution name
+/// itself.
+struct ImportResolver<'a> {
+    custom: Option<&'a FxHashMap<String, Vec<String>>>,
+    environment: &'a EnvironmentMapping,
+    builtin: &'static FxHashMap<&'static str, Vec<&'static str>>,
+    builtin_reverse: &'static FxHashMap<&'static str, &'static str>,
+}
+
+/// Import names derived from the packages installed in the virtual environment.
+#[derive(Default)]
+struct EnvironmentMapping {
+    /// Normalized distribution name → the import names it provides.
+    forward: FxHashMap<String, Vec<String>>,
+    /// Import name → the normalized distribution name providing it.
+    reverse: FxHashMap<String, String>,
+}
+
+fn environment_mapping(installed: &FxHashMap<String, InstalledPackage>) -> EnvironmentMapping {
+    let mut mapping = EnvironmentMapping::default();
+    for (normalized, pkg) in installed {
+        if pkg.top_level.is_empty() {
+            continue;
+        }
+        for import_name in &pkg.top_level {
+            mapping
+                .reverse
+                .entry(import_name.clone())
+                .or_insert_with(|| normalized.clone());
+        }
+        mapping
+            .forward
+            .insert(normalized.clone(), pkg.top_level.clone());
+    }
+    mapping
+}
+
+impl ImportResolver<'_> {
+    /// The import names a declared dependency is expected to provide.
+    fn imports_for<'b>(&'b self, dep: &'b DeclaredDependency) -> Vec<&'b str> {
+        if let Some(names) = self.custom.and_then(|custom| {
+            custom
+                .get(dep.package_name.as_str())
+                .or_else(|| custom.get(dep.normalized_name.as_str()))
+        }) {
+            return names.iter().map(String::as_str).collect();
+        }
+        if let Some(names) = self.environment.forward.get(&dep.normalized_name) {
+            return names.iter().map(String::as_str).collect();
+        }
+        if let Some(names) = self
+            .builtin
+            .get(dep.package_name.as_str())
+            .or_else(|| self.builtin.get(dep.normalized_name.as_str()))
+        {
+            return names.clone();
+        }
+        vec![dep.normalized_name.as_str()]
+    }
+
+    /// The normalized distribution name an import most likely comes from.
+    fn distribution_for(&self, import_name: &str) -> String {
+        let import_lower = import_name.to_lowercase();
+        if let Some(dist) = self
+            .environment
+            .reverse
+            .get(import_name)
+            .or_else(|| self.environment.reverse.get(&import_lower))
+        {
+            return dist.clone();
+        }
+        let guess = self
+            .builtin_reverse
+            .get(import_name)
+            .or_else(|| self.builtin_reverse.get(import_lower.as_str()))
+            .copied()
+            .unwrap_or(import_lower.as_str());
+        super::declared::normalize_package_name(guess)
+    }
+}
+
 // ── Step helpers ─────────────────────────────────────────────────────────────
 
 fn find_unused_declared(
     declared: &[DeclaredDependency],
     imported: &FxHashSet<String>,
     options: &DepsOptions<'_>,
-    pkg_mapping: &FxHashMap<&'static str, Vec<&'static str>>,
+    resolver: &ImportResolver<'_>,
     stdlib_modules: &FxHashSet<&'static str>,
     lockfile_reachable: Option<&FxHashSet<String>>,
 ) -> Vec<DeclaredDependency> {
@@ -213,23 +349,15 @@ fn find_unused_declared(
             continue;
         }
 
-        let custom_expected = options.package_mapping.and_then(|m| {
-            m.get(dep.package_name.as_str())
-                .or_else(|| m.get(dep.normalized_name.as_str()))
-        });
+        let expected_imports = resolver.imports_for(dep);
 
-        let expected_imports: Vec<&str> = match custom_expected {
-            Some(names) => names.iter().map(std::string::String::as_str).collect(),
-            None => match pkg_mapping
-                .get(dep.package_name.as_str())
-                .or_else(|| pkg_mapping.get(dep.normalized_name.as_str()))
-            {
-                Some(names) => names.clone(),
-                None => vec![dep.normalized_name.as_str()],
-            },
-        };
+        // A distribution in a namespace package is imported through its namespace
+        // root (`from google.cloud import storage` uses `google-cloud-storage`),
+        // so the root counts as usage of every declared dist under it.
+        let namespace_used = namespace_root_for_dist(&dep.normalized_name)
+            .is_some_and(|root| imported.contains(root));
 
-        if !expected_imports.iter().any(|e| imported.contains(*e)) {
+        if !namespace_used && !expected_imports.iter().any(|e| imported.contains(*e)) {
             unused.push(dep.clone());
         }
     }
@@ -252,19 +380,6 @@ fn should_treat_requirements_dep_as_export_pin(
         )
 }
 
-fn package_name_for_import(
-    import_name: &str,
-    reverse_mapping: &FxHashMap<&'static str, &'static str>,
-) -> String {
-    let import_lower = import_name.to_lowercase();
-    let pkg_name_guess = reverse_mapping
-        .get(import_name)
-        .or_else(|| reverse_mapping.get(import_lower.as_str()))
-        .copied()
-        .unwrap_or(import_lower.as_str());
-    super::declared::normalize_package_name(pkg_name_guess)
-}
-
 fn reachable_lockfile_packages(
     declared: &[DeclaredDependency],
     graph: &super::lockfile::LockfileGraph,
@@ -277,11 +392,9 @@ fn reachable_lockfile_packages(
 }
 
 fn declared_namespace_matches(import_name: &str, declared_names: &FxHashSet<String>) -> bool {
-    const KNOWN_NAMESPACE_IMPORTS: &[&str] = &["azure", "google", "zope"];
-    KNOWN_NAMESPACE_IMPORTS.contains(&import_name)
-        && declared_names.iter().any(|name| {
-            name.starts_with(import_name) && name.as_bytes().get(import_name.len()) == Some(&b'_')
-        })
+    declared_names
+        .iter()
+        .any(|name| dist_is_in_namespace(name, import_name))
 }
 
 type OccurrenceIndex<'a> = FxHashMap<&'a str, Vec<&'a ImportOccurrence>>;
@@ -316,8 +429,8 @@ fn find_missing_imports(
     occurrences: &OccurrenceIndex<'_>,
     declared: &[DeclaredDependency],
     options: &DepsOptions<'_>,
+    resolver: &ImportResolver<'_>,
     stdlib_modules: &FxHashSet<&'static str>,
-    reverse_mapping: &FxHashMap<&'static str, &'static str>,
     lockfile_reachable: Option<&FxHashSet<String>>,
 ) -> Vec<MissingDependency> {
     // Pre-build a set of all declared names (original and normalized) for O(1) lookup.
@@ -339,7 +452,7 @@ fn find_missing_imports(
         }
 
         let import_lower = import_name.to_lowercase();
-        let pkg_normalized = package_name_for_import(import_name, reverse_mapping);
+        let pkg_normalized = resolver.distribution_for(import_name);
         let is_transitive = lockfile_reachable.is_some_and(|reachable| {
             reachable.contains(&pkg_normalized) && !declared_names.contains(&pkg_normalized)
         });
@@ -368,8 +481,8 @@ fn find_transitive_imports(
     occurrences: &OccurrenceIndex<'_>,
     declared: &[DeclaredDependency],
     options: &DepsOptions<'_>,
+    resolver: &ImportResolver<'_>,
     stdlib_modules: &FxHashSet<&'static str>,
-    reverse_mapping: &FxHashMap<&'static str, &'static str>,
     lockfile_reachable: Option<&FxHashSet<String>>,
 ) -> Vec<TransitiveDependency> {
     let Some(reachable) = lockfile_reachable else {
@@ -389,7 +502,7 @@ fn find_transitive_imports(
         {
             continue;
         }
-        let package_name = package_name_for_import(import_name, reverse_mapping);
+        let package_name = resolver.distribution_for(import_name);
         if reachable.contains(&package_name) && !declared_norm.contains(&package_name) {
             transitive.push(TransitiveDependency {
                 import_name: import_name.clone(),
@@ -418,7 +531,7 @@ fn find_dev_dependencies_in_production(
     production_imports: &FxHashSet<String>,
     occurrences: &OccurrenceIndex<'_>,
     options: &DepsOptions<'_>,
-    pkg_mapping: &FxHashMap<&'static str, Vec<&'static str>>,
+    resolver: &ImportResolver<'_>,
 ) -> Vec<DevDependencyInProduction> {
     let production_declared: FxHashSet<&str> = declared
         .iter()
@@ -437,30 +550,25 @@ fn find_dev_dependencies_in_production(
         {
             continue;
         }
-        let custom_expected = options.package_mapping.and_then(|m| {
-            m.get(dep.package_name.as_str())
-                .or_else(|| m.get(dep.normalized_name.as_str()))
-        });
-        let expected_imports: Vec<&str> = match custom_expected {
-            Some(names) => names.iter().map(std::string::String::as_str).collect(),
-            None => match pkg_mapping
-                .get(dep.package_name.as_str())
-                .or_else(|| pkg_mapping.get(dep.normalized_name.as_str()))
-            {
-                Some(names) => names.clone(),
-                None => vec![dep.normalized_name.as_str()],
-            },
+        // One dependency can map to several import names (`attrs` → `attr`, `attrs`).
+        // Report it once, with the evidence from every import name that was used.
+        let used: Vec<&str> = resolver
+            .imports_for(dep)
+            .into_iter()
+            .filter(|name| production_imports.contains(*name))
+            .collect();
+        let Some(primary) = used.first() else {
+            continue;
         };
 
-        for import_name in expected_imports {
-            if production_imports.contains(import_name) {
-                findings.push(DevDependencyInProduction {
-                    import_name: import_name.to_owned(),
-                    dependency: dep.clone(),
-                    locations: locations_for_import(occurrences, import_name, true),
-                });
-            }
-        }
+        findings.push(DevDependencyInProduction {
+            import_name: (*primary).to_owned(),
+            dependency: dep.clone(),
+            locations: used
+                .iter()
+                .flat_map(|name| locations_for_import(occurrences, name, true))
+                .collect(),
+        });
     }
     findings.sort_by(|a, b| {
         a.dependency
@@ -471,13 +579,28 @@ fn find_dev_dependencies_in_production(
     findings
 }
 
-fn scan_environment(
+/// Loads the packages installed in the project's virtual environment. The result
+/// drives the extra/orphan reports and, more importantly, the import-name
+/// mapping, so it is loaded whenever a venv is present.
+fn load_installed(
     options: &DepsOptions<'_>,
     primary_root: &Path,
+) -> FxHashMap<String, InstalledPackage> {
+    options
+        .venv_path
+        .clone()
+        .or_else(|| detect_venv(primary_root))
+        .map(|venv| scan_installed(&venv))
+        .unwrap_or_default()
+}
+
+fn scan_environment(
+    options: &DepsOptions<'_>,
+    installed: &FxHashMap<String, InstalledPackage>,
     declared: &[DeclaredDependency],
     imported: &FxHashSet<String>,
     stdlib_modules: &FxHashSet<&'static str>,
-    reverse_mapping: &FxHashMap<&'static str, &'static str>,
+    resolver: &ImportResolver<'_>,
 ) -> (Vec<InstalledPackage>, Vec<InstalledPackage>) {
     let mut extra_installed = Vec::new();
     let mut orphan_installed = Vec::new();
@@ -486,36 +609,17 @@ fn scan_environment(
         return (extra_installed, orphan_installed);
     }
 
-    let venv_root = options
-        .venv_path
-        .clone()
-        .or_else(|| detect_venv(primary_root));
-
-    let Some(venv) = venv_root else {
-        return (extra_installed, orphan_installed);
-    };
-
-    let installed = scan_installed(&venv);
-
     // Declared normalized names for fast lookup
     let declared_norm: FxHashSet<String> =
         declared.iter().map(|d| d.normalized_name.clone()).collect();
 
-    // Imported normalized names for orphan detection
+    // Imported names resolved back to the distributions that provide them.
     let imported_norm: FxHashSet<String> = imported
         .iter()
-        .map(|i| {
-            let i_lower = i.to_lowercase();
-            // Try original casing first (handles "PIL"), then lowercase.
-            reverse_mapping
-                .get(i.as_str())
-                .or_else(|| reverse_mapping.get(i_lower.as_str()))
-                .map(|s| super::declared::normalize_package_name(s))
-                .unwrap_or_else(|| super::declared::normalize_package_name(&i_lower))
-        })
+        .map(|import_name| resolver.distribution_for(import_name))
         .collect();
 
-    for (norm_name, pkg) in &installed {
+    for (norm_name, pkg) in installed {
         // Skip packages that are declared
         if declared_norm.contains(norm_name) {
             continue;
@@ -609,20 +713,37 @@ fn build_removable_branches(
 
 /// Analyzes dependencies across the project given the provided options.
 pub fn analyze_dependencies(options: &DepsOptions<'_>) -> DepsResult {
-    let primary_root = options
+    let analysis_root = options
         .roots
         .first()
         .map(std::path::PathBuf::as_path)
         .unwrap_or_else(|| Path::new("."));
+    // Manifests, lockfiles and the venv live at the project root, which is not
+    // necessarily the directory being analyzed (`cytoscnpy deps src/`).
+    let project_root = super::declared::find_project_root(analysis_root);
+    let primary_root = project_root.as_path();
 
     let declared = locate_and_parse_declarations(primary_root, options.requirements.as_ref());
     let import_scan = extract_import_scan(options.roots, options.exclude, options.verbose);
     let imported = &import_scan.all;
+    // Imports under `if TYPE_CHECKING:` are not runtime imports, so they never make
+    // a dependency "missing", but they do keep a declared dependency from looking unused.
+    let used_at_all: FxHashSet<String> = imported
+        .iter()
+        .chain(import_scan.type_checking.iter())
+        .cloned()
+        .collect();
     let occurrence_index = index_occurrences(&import_scan.occurrences);
 
-    let pkg_mapping = get_package_mapping();
     let stdlib_modules = get_stdlib_modules();
-    let reverse_mapping = get_reverse_mapping();
+    let installed = load_installed(options, primary_root);
+    let environment = environment_mapping(&installed);
+    let resolver = ImportResolver {
+        custom: options.package_mapping,
+        environment: &environment,
+        builtin: get_package_mapping(),
+        builtin_reverse: get_reverse_mapping(),
+    };
     let lockfile_graph = match options.lockfile_path.as_deref() {
         Some(path) => load_lockfile_graph_at(path),
         None => load_lockfile_graph(primary_root),
@@ -633,9 +754,9 @@ pub fn analyze_dependencies(options: &DepsOptions<'_>) -> DepsResult {
 
     let unused = find_unused_declared(
         &declared,
-        imported,
+        &used_at_all,
         options,
-        pkg_mapping,
+        &resolver,
         stdlib_modules,
         lockfile_reachable.as_ref(),
     );
@@ -644,8 +765,8 @@ pub fn analyze_dependencies(options: &DepsOptions<'_>) -> DepsResult {
         &occurrence_index,
         &declared,
         options,
+        &resolver,
         stdlib_modules,
-        reverse_mapping,
         lockfile_reachable.as_ref(),
     );
     let transitive = find_transitive_imports(
@@ -653,8 +774,8 @@ pub fn analyze_dependencies(options: &DepsOptions<'_>) -> DepsResult {
         &occurrence_index,
         &declared,
         options,
+        &resolver,
         stdlib_modules,
-        reverse_mapping,
         lockfile_reachable.as_ref(),
     );
     let dev_in_production = find_dev_dependencies_in_production(
@@ -662,16 +783,16 @@ pub fn analyze_dependencies(options: &DepsOptions<'_>) -> DepsResult {
         &import_scan.production,
         &occurrence_index,
         options,
-        pkg_mapping,
+        &resolver,
     );
     let stdlib = find_stdlib_declarations(&declared, stdlib_modules);
     let (extra_installed, orphan_installed) = scan_environment(
         options,
-        primary_root,
+        &installed,
         &declared,
         imported,
         stdlib_modules,
-        reverse_mapping,
+        &resolver,
     );
     let removable_branches = build_removable_branches(options, primary_root, &declared, &unused);
 

--- a/cytoscnpy/src/deps/analysis_tests.rs
+++ b/cytoscnpy/src/deps/analysis_tests.rs
@@ -595,6 +595,73 @@ fn a_user_package_mapping_overrides_the_environment() {
 }
 
 #[test]
+fn a_user_mapped_import_resolves_back_to_the_declared_distribution() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(
+        dir.path(),
+        "pyproject.toml",
+        &pyproject("\"my-internal-lib\""),
+    );
+    write(dir.path(), "app.py", "import mylib\n");
+
+    let mut mapping = rustc_hash::FxHashMap::default();
+    mapping.insert("my-internal-lib".to_owned(), vec!["mylib".to_owned()]);
+
+    let roots = vec![dir.path().to_path_buf()];
+    let mut opts = options(&roots);
+    opts.package_mapping = Some(&mapping);
+    let result = analyze_dependencies(&opts);
+
+    assert!(
+        result.missing.is_empty(),
+        "the mapping says `mylib` comes from the declared `my-internal-lib`: {:?}",
+        result.missing
+    );
+    assert!(result.unused.is_empty(), "my-internal-lib is imported");
+}
+
+#[test]
+fn a_namespace_import_is_not_transitive_when_a_declared_dist_publishes_into_it() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(
+        dir.path(),
+        "pyproject.toml",
+        &pyproject("\"google-cloud-storage\""),
+    );
+    write(dir.path(), "app.py", "from google.cloud import storage\n");
+    write(
+        dir.path(),
+        "uv.lock",
+        "version = 1\n\n\
+         [[package]]\n\
+         name = \"google-cloud-storage\"\n\
+         version = \"2.0.0\"\n\
+         dependencies = [\n  { name = \"google-api-core\" },\n]\n\n\
+         [[package]]\n\
+         name = \"google-api-core\"\n\
+         version = \"2.0.0\"\n",
+    );
+    // Both distributions record `google` as their import root, and the reverse
+    // map can pick either one for the shared namespace.
+    install(dir.path(), "google_api_core", &["google"], &[]);
+    install(dir.path(), "google_cloud_storage", &["google"], &[]);
+
+    let roots = vec![dir.path().to_path_buf()];
+    let result = analyze_dependencies(&options(&roots));
+
+    assert!(
+        result.transitive.is_empty(),
+        "`google` is published by the declared google-cloud-storage: {:?}",
+        result
+            .transitive
+            .iter()
+            .map(|dep| dep.package_name.as_str())
+            .collect::<Vec<_>>()
+    );
+    assert!(result.missing.is_empty(), "google is declared");
+}
+
+#[test]
 fn an_imported_undeclared_package_is_missing_with_source_evidence() {
     let (_dir, result) = analyze(&[
         ("pyproject.toml", &pyproject("")),

--- a/cytoscnpy/src/deps/analysis_tests.rs
+++ b/cytoscnpy/src/deps/analysis_tests.rs
@@ -1,0 +1,608 @@
+use super::analysis::{analyze_dependencies, DepsOptions, DepsResult};
+use super::declared::DeclaredDependency;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn options(roots: &[PathBuf]) -> DepsOptions<'_> {
+    DepsOptions {
+        roots,
+        exclude: &[],
+        requirements: None,
+        ignore_unused: &[],
+        ignore_missing: &[],
+        verbose: false,
+        json: false,
+        package_mapping: None,
+        venv_path: None,
+        lockfile_path: None,
+        show_extra: false,
+        show_orphans: false,
+        impact_package: None,
+        include_dev_unused: false,
+    }
+}
+
+fn write(dir: &Path, relative: &str, content: &str) {
+    let path = dir.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent dir");
+    }
+    fs::write(path, content).expect("write file");
+}
+
+/// Builds a project from `(relative path, content)` pairs and analyzes it,
+/// treating `root` as the single analysis root.
+fn analyze(files: &[(&str, &str)]) -> (TempDir, DepsResult) {
+    analyze_from(files, "")
+}
+
+/// Same as [`analyze`], but the analysis root is `subdir` inside the project.
+fn analyze_from(files: &[(&str, &str)], subdir: &str) -> (TempDir, DepsResult) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for (relative, content) in files {
+        write(dir.path(), relative, content);
+    }
+    let roots = vec![dir.path().join(subdir)];
+    let result = analyze_dependencies(&options(&roots));
+    (dir, result)
+}
+
+fn unused_names(unused: &[DeclaredDependency]) -> Vec<&str> {
+    unused.iter().map(|dep| dep.package_name.as_str()).collect()
+}
+
+const PYPROJECT_HEADER: &str = "[project]\nname = \"proj\"\nversion = \"0.1.0\"\n";
+
+fn pyproject(dependencies: &str) -> String {
+    format!("{PYPROJECT_HEADER}dependencies = [{dependencies}]\n")
+}
+
+#[test]
+fn namespace_distribution_used_through_its_namespace_root_is_not_unused() {
+    let (_dir, result) = analyze(&[
+        (
+            "pyproject.toml",
+            &pyproject("\"google-cloud-storage\", \"azure-storage-blob\""),
+        ),
+        (
+            "app.py",
+            "from google.cloud import storage\nfrom azure.storage.blob import BlobClient\n",
+        ),
+    ]);
+
+    assert!(
+        result.unused.is_empty(),
+        "namespace dists imported via their root must not be unused: {:?}",
+        unused_names(&result.unused)
+    );
+    assert!(result.missing.is_empty(), "missing: {:?}", result.missing);
+}
+
+#[test]
+fn dotted_distribution_name_matches_its_namespace_import() {
+    let (_dir, result) = analyze(&[
+        ("pyproject.toml", &pyproject("\"ruamel.yaml\"")),
+        ("app.py", "from ruamel.yaml import YAML\n"),
+    ]);
+
+    assert!(
+        result.unused.is_empty(),
+        "ruamel.yaml is used: {:?}",
+        unused_names(&result.unused)
+    );
+    assert!(
+        result.missing.is_empty(),
+        "`ruamel` is provided by the declared ruamel.yaml: {:?}",
+        result.missing
+    );
+}
+
+#[test]
+fn unrelated_distribution_sharing_a_name_prefix_is_still_unused() {
+    // `googlemaps` is not a `google` namespace dist, so importing `google`
+    // must not mark it used.
+    let (_dir, result) = analyze(&[
+        ("pyproject.toml", &pyproject("\"googlemaps\"")),
+        ("app.py", "from google.cloud import storage\n"),
+    ]);
+
+    assert_eq!(unused_names(&result.unused), vec!["googlemaps"]);
+}
+
+#[test]
+fn first_party_package_under_src_layout_is_not_missing() {
+    let (_dir, result) = analyze(&[
+        ("pyproject.toml", &pyproject("")),
+        ("src/mypkg/__init__.py", ""),
+        ("tests/test_app.py", "import mypkg\n"),
+    ]);
+
+    assert!(
+        result.missing.is_empty(),
+        "src-layout package is first-party: {:?}",
+        result.missing
+    );
+}
+
+#[test]
+fn declarations_are_found_when_analyzing_a_subdirectory() {
+    let (_dir, result) = analyze_from(
+        &[
+            ("pyproject.toml", &pyproject("\"requests\"")),
+            ("src/app.py", "import requests\n"),
+        ],
+        "src",
+    );
+
+    assert!(
+        result.missing.is_empty(),
+        "pyproject at the project root must still be read: {:?}",
+        result.missing
+    );
+    assert!(result.unused.is_empty(), "requests is imported");
+}
+
+#[test]
+fn dependency_imported_only_under_type_checking_is_not_unused_nor_missing() {
+    let source = "from typing import TYPE_CHECKING\n\
+                  if TYPE_CHECKING:\n    import pandas\n\n\
+                  def f(df: 'pandas.DataFrame') -> None: ...\n";
+    let (_dir, result) = analyze(&[
+        ("pyproject.toml", &pyproject("\"pandas\"")),
+        ("app.py", source),
+    ]);
+
+    assert!(
+        result.unused.is_empty(),
+        "a type-only import still uses the dependency: {:?}",
+        unused_names(&result.unused)
+    );
+    assert!(
+        result.missing.is_empty(),
+        "type-only imports are not runtime imports: {:?}",
+        result.missing
+    );
+}
+
+#[test]
+fn undeclared_type_checking_import_is_not_reported_as_missing() {
+    let source = "from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    import pandas\n";
+    let (_dir, result) = analyze(&[("pyproject.toml", &pyproject("")), ("app.py", source)]);
+
+    assert!(
+        result.missing.is_empty(),
+        "type-only imports never make a dependency missing: {:?}",
+        result.missing
+    );
+}
+
+#[test]
+fn dev_dependency_with_several_import_names_is_reported_once() {
+    let manifest =
+        format!("{PYPROJECT_HEADER}dependencies = []\n\n[dependency-groups]\ndev = [\"attrs\"]\n");
+    let (_dir, result) = analyze(&[
+        ("pyproject.toml", &manifest),
+        ("app.py", "import attr\nimport attrs\n"),
+    ]);
+
+    assert_eq!(
+        result.dev_in_production.len(),
+        1,
+        "attrs maps to two import names but is one dependency: {:?}",
+        result
+            .dev_in_production
+            .iter()
+            .map(|f| f.import_name.clone())
+            .collect::<Vec<_>>()
+    );
+    let finding = &result.dev_in_production[0];
+    assert_eq!(finding.dependency.package_name, "attrs");
+    assert_eq!(
+        finding.locations.len(),
+        2,
+        "evidence from both import names is kept"
+    );
+}
+
+#[test]
+fn requirements_include_directives_are_followed() {
+    let (_dir, result) = analyze(&[
+        ("requirements.txt", "requests\n"),
+        ("requirements-dev.txt", "-r requirements.txt\npytest\n"),
+        ("app.py", "import requests\nimport pytest\n"),
+    ]);
+
+    assert!(result.missing.is_empty(), "missing: {:?}", result.missing);
+    assert!(
+        result
+            .unused
+            .iter()
+            .all(|dep| dep.package_name != "requests"),
+        "requests is imported"
+    );
+}
+
+#[test]
+fn requirements_include_cycles_terminate() {
+    let (_dir, result) = analyze(&[
+        ("requirements.txt", "-r requirements-dev.txt\nrequests\n"),
+        ("requirements-dev.txt", "-r requirements.txt\npytest\n"),
+        ("app.py", "import requests\n"),
+    ]);
+
+    assert!(result.missing.is_empty(), "missing: {:?}", result.missing);
+}
+
+#[test]
+fn a_declared_dependency_that_is_never_imported_is_still_unused() {
+    let (_dir, result) = analyze(&[
+        ("pyproject.toml", &pyproject("\"requests\", \"httpx\"")),
+        ("app.py", "import requests\n"),
+    ]);
+
+    assert_eq!(unused_names(&result.unused), vec!["httpx"]);
+}
+
+#[test]
+fn namespace_and_extension_modules_count_as_first_party() {
+    // A PEP 420 namespace package (no __init__.py), a bare directory whose only
+    // Python content is a nested package, a single-file module, a stub-only
+    // module, and a compiled extension module are all first-party.
+    let (_dir, result) = analyze(&[
+        ("pyproject.toml", &pyproject("")),
+        ("nspkg/mod.py", ""),
+        ("outer/inner/__init__.py", ""),
+        ("single.py", ""),
+        ("stubbed.pyi", ""),
+        ("native.pyd", ""),
+        (
+            "app.py",
+            "import nspkg\nimport outer\nimport single\nimport stubbed\nimport native\n",
+        ),
+    ]);
+
+    assert!(
+        result.missing.is_empty(),
+        "namespace, nested, single-file, stub and extension modules are first-party: {:?}",
+        result.missing
+    );
+}
+
+#[test]
+fn an_empty_directory_is_not_a_local_package() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(dir.path(), "pyproject.toml", &pyproject(""));
+    write(dir.path(), "app.py", "import ghost\n");
+    fs::create_dir_all(dir.path().join("ghost")).expect("create empty dir");
+
+    let roots = vec![dir.path().to_path_buf()];
+    let result = analyze_dependencies(&options(&roots));
+
+    assert_eq!(
+        result.missing,
+        vec!["ghost".to_owned()],
+        "a directory with no Python content is not a package"
+    );
+}
+
+#[test]
+fn extra_and_orphan_installed_packages_are_reported_from_the_venv() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(dir.path(), "pyproject.toml", &pyproject("\"requests\""));
+    write(dir.path(), "app.py", "import requests\n");
+
+    // requests: declared. urllib3: undeclared but required by requests. bloat: neither.
+    let site_packages = dir.path().join(".venv/Lib/site-packages");
+    for (name, requires) in [
+        ("requests", "Requires-Dist: urllib3\n"),
+        ("urllib3", ""),
+        ("bloat", ""),
+    ] {
+        let info = site_packages.join(format!("{name}-1.0.dist-info"));
+        fs::create_dir_all(&info).expect("create dist-info");
+        fs::write(
+            info.join("METADATA"),
+            format!("Name: {name}\nVersion: 1.0\n{requires}"),
+        )
+        .expect("write METADATA");
+    }
+
+    let roots = vec![dir.path().to_path_buf()];
+    let mut opts = options(&roots);
+    opts.show_extra = true;
+    opts.show_orphans = true;
+    let result = analyze_dependencies(&opts);
+
+    let extra: Vec<&str> = result
+        .extra_installed
+        .iter()
+        .map(|pkg| pkg.normalized_name.as_str())
+        .collect();
+    assert_eq!(
+        extra,
+        vec!["bloat", "urllib3"],
+        "declared packages are not extra"
+    );
+
+    let orphans: Vec<&str> = result
+        .orphan_installed
+        .iter()
+        .map(|pkg| pkg.normalized_name.as_str())
+        .collect();
+    assert_eq!(
+        orphans,
+        vec!["bloat"],
+        "urllib3 is required by requests, so it is not an orphan"
+    );
+}
+
+/// `requests` (declared) pulls in `urllib3` and `certifi`; `httpx` (declared,
+/// unused) pulls in `anyio`, which nothing else needs.
+const UV_LOCK: &str = "\
+version = 1
+
+[[package]]
+name = \"requests\"
+version = \"2.31.0\"
+dependencies = [
+  { name = \"urllib3\" },
+  { name = \"certifi\" },
+]
+
+[[package]]
+name = \"httpx\"
+version = \"0.27.0\"
+dependencies = [
+  { name = \"anyio\" },
+  { name = \"certifi\" },
+]
+
+[[package]]
+name = \"urllib3\"
+version = \"2.0.0\"
+
+[[package]]
+name = \"certifi\"
+version = \"2024.1.1\"
+
+[[package]]
+name = \"anyio\"
+version = \"4.0.0\"
+";
+
+#[test]
+fn an_import_satisfied_only_by_a_transitive_lockfile_package_is_reported_as_transitive() {
+    let (_dir, result) = analyze(&[
+        ("pyproject.toml", &pyproject("\"requests\"")),
+        ("uv.lock", UV_LOCK),
+        ("app.py", "import requests\nimport urllib3\n"),
+    ]);
+
+    let transitive: Vec<&str> = result
+        .transitive
+        .iter()
+        .map(|dep| dep.import_name.as_str())
+        .collect();
+    assert_eq!(transitive, vec!["urllib3"]);
+    assert_eq!(result.transitive[0].package_name, "urllib3");
+    assert!(
+        !result.transitive[0].locations.is_empty(),
+        "evidence is kept"
+    );
+    assert!(
+        result.missing.is_empty(),
+        "a transitively available import is not `missing`: {:?}",
+        result.missing
+    );
+}
+
+#[test]
+fn removable_branches_exclude_packages_still_needed_by_other_declared_roots() {
+    let (_dir, result) = analyze(&[
+        ("pyproject.toml", &pyproject("\"requests\", \"httpx\"")),
+        ("uv.lock", UV_LOCK),
+        ("app.py", "import requests\n"),
+    ]);
+
+    assert_eq!(unused_names(&result.unused), vec!["httpx"]);
+    assert_eq!(result.removable_branches.len(), 1);
+    let branch = &result.removable_branches[0];
+    assert_eq!(branch.root, "httpx");
+    assert_eq!(
+        branch.unique_transitive,
+        vec!["anyio".to_owned()],
+        "certifi is still required by the declared `requests`, so it is not removable"
+    );
+}
+
+#[test]
+fn impact_package_reports_the_branch_for_one_package_only() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(
+        dir.path(),
+        "pyproject.toml",
+        &pyproject("\"requests\", \"httpx\""),
+    );
+    write(dir.path(), "uv.lock", UV_LOCK);
+    write(dir.path(), "app.py", "import requests\nimport httpx\n");
+
+    let roots = vec![dir.path().to_path_buf()];
+    let mut opts = options(&roots);
+    opts.impact_package = Some("requests".to_owned());
+    let result = analyze_dependencies(&opts);
+
+    assert!(result.unused.is_empty(), "both packages are imported");
+    assert_eq!(
+        result.removable_branches.len(),
+        1,
+        "impact is reported for the requested package even when it is used"
+    );
+    assert_eq!(result.removable_branches[0].root, "requests");
+    assert_eq!(
+        result.removable_branches[0].unique_transitive,
+        vec!["urllib3".to_owned()],
+        "certifi is shared with httpx"
+    );
+}
+
+#[test]
+fn a_setuptools_project_declares_its_dependencies_in_setup_py() {
+    let (_dir, result) = analyze(&[
+        (
+            "setup.py",
+            "from setuptools import setup\nsetup(name='proj', install_requires=['requests'])\n",
+        ),
+        ("app.py", "import requests\n"),
+    ]);
+
+    assert!(
+        result.missing.is_empty(),
+        "install_requires is a declaration, and setup.py's own build imports are not \
+         dependencies: {:?}",
+        result.missing
+    );
+    assert!(result.unused.is_empty(), "requests is imported");
+}
+
+#[test]
+fn a_setuptools_project_declares_its_dependencies_in_setup_cfg() {
+    let (_dir, result) = analyze(&[
+        (
+            "setup.cfg",
+            "[options]\ninstall_requires =\n    requests\n    flask\n",
+        ),
+        ("app.py", "import requests\n"),
+    ]);
+
+    assert!(result.missing.is_empty(), "missing: {:?}", result.missing);
+    assert_eq!(unused_names(&result.unused), vec!["flask"]);
+}
+
+/// Installs `name` into a fake venv under `dir`, recording the import names it
+/// provides in `top_level.txt` the way a real installer does.
+fn install(dir: &Path, name: &str, top_level: &[&str], requires: &[&str]) {
+    let info = dir
+        .join(".venv/Lib/site-packages")
+        .join(format!("{name}-1.0.dist-info"));
+    fs::create_dir_all(&info).expect("create dist-info");
+
+    let mut metadata = format!("Name: {name}\nVersion: 1.0\n");
+    for req in requires {
+        metadata.push_str(&format!("Requires-Dist: {req}\n"));
+    }
+    fs::write(info.join("METADATA"), metadata).expect("write METADATA");
+
+    if !top_level.is_empty() {
+        fs::write(
+            info.join("top_level.txt"),
+            format!("{}\n", top_level.join("\n")),
+        )
+        .expect("write top_level.txt");
+    }
+}
+
+#[test]
+fn import_names_come_from_the_installed_environment_not_a_guess_table() {
+    // `python-slugify` imports as `slugify`. It is in no built-in table, so before
+    // the environment was consulted this was both "unused" and "missing".
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(
+        dir.path(),
+        "pyproject.toml",
+        &pyproject("\"python-slugify\""),
+    );
+    write(dir.path(), "app.py", "from slugify import slugify\n");
+    install(dir.path(), "python_slugify", &["slugify"], &[]);
+
+    let roots = vec![dir.path().to_path_buf()];
+    let result = analyze_dependencies(&options(&roots));
+
+    assert!(
+        result.unused.is_empty(),
+        "top_level.txt says python-slugify provides `slugify`: {:?}",
+        unused_names(&result.unused)
+    );
+    assert!(result.missing.is_empty(), "missing: {:?}", result.missing);
+}
+
+#[test]
+fn without_an_environment_the_builtin_table_still_applies() {
+    let (_dir, result) = analyze(&[
+        (
+            "pyproject.toml",
+            &pyproject("\"pyyaml\", \"python-slugify\""),
+        ),
+        ("app.py", "import yaml\nfrom slugify import slugify\n"),
+    ]);
+
+    assert_eq!(
+        unused_names(&result.unused),
+        vec!["python-slugify"],
+        "pyyaml→yaml is in the built-in table; python-slugify can only be resolved \
+         from an environment"
+    );
+}
+
+#[test]
+fn the_environment_mapping_resolves_imports_back_to_their_distribution() {
+    // `slugify` is imported but undeclared. The environment knows which
+    // distribution provides it, so the orphan report must not treat that
+    // distribution as unused-and-unreferenced.
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(dir.path(), "pyproject.toml", &pyproject(""));
+    write(dir.path(), "app.py", "from slugify import slugify\n");
+    install(dir.path(), "python_slugify", &["slugify"], &[]);
+    install(dir.path(), "bloat", &["bloat"], &[]);
+
+    let roots = vec![dir.path().to_path_buf()];
+    let mut opts = options(&roots);
+    opts.show_orphans = true;
+    let result = analyze_dependencies(&opts);
+
+    let orphans: Vec<&str> = result
+        .orphan_installed
+        .iter()
+        .map(|pkg| pkg.normalized_name.as_str())
+        .collect();
+    assert_eq!(
+        orphans,
+        vec!["bloat"],
+        "python-slugify is imported as `slugify`, so it is not an orphan"
+    );
+}
+
+#[test]
+fn a_user_package_mapping_overrides_the_environment() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(dir.path(), "pyproject.toml", &pyproject("\"weird-dist\""));
+    write(dir.path(), "app.py", "import chosen\n");
+    install(dir.path(), "weird_dist", &["ignored"], &[]);
+
+    let mut mapping = rustc_hash::FxHashMap::default();
+    mapping.insert("weird-dist".to_owned(), vec!["chosen".to_owned()]);
+
+    let roots = vec![dir.path().to_path_buf()];
+    let mut opts = options(&roots);
+    opts.package_mapping = Some(&mapping);
+    let result = analyze_dependencies(&opts);
+
+    assert!(
+        result.unused.is_empty(),
+        "the configured mapping wins over top_level.txt: {:?}",
+        unused_names(&result.unused)
+    );
+}
+
+#[test]
+fn an_imported_undeclared_package_is_missing_with_source_evidence() {
+    let (_dir, result) = analyze(&[
+        ("pyproject.toml", &pyproject("")),
+        ("app.py", "import os\nimport requests\n"),
+    ]);
+
+    assert_eq!(result.missing, vec!["requests".to_owned()]);
+    let detail = &result.missing_details[0];
+    assert_eq!(detail.locations.len(), 1);
+    assert_eq!(detail.locations[0].line, 2);
+}

--- a/cytoscnpy/src/deps/declared.rs
+++ b/cytoscnpy/src/deps/declared.rs
@@ -1,14 +1,16 @@
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use toml::Value;
 
 /// Origin of a declared dependency.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum DependencySource {
     /// Declared in pyproject.toml.
     Pyproject,
     /// Declared in a requirements.txt file.
     Requirements(String),
+    /// Declared in a setuptools file (`setup.py` or `setup.cfg`).
+    Setup(String),
 }
 
 /// Represents a dependency declared in the project configuration.
@@ -38,7 +40,7 @@ pub fn extract_package_name_from_pep508(spec: &str) -> Option<String> {
     extract_pep508_parts(spec).map(|(name, _)| name)
 }
 
-fn extract_pep508_parts(spec: &str) -> Option<(String, Option<String>)> {
+pub(super) fn extract_pep508_parts(spec: &str) -> Option<(String, Option<String>)> {
     let spec = spec.trim();
     if spec.is_empty() || spec.starts_with('#') {
         return None;
@@ -184,35 +186,94 @@ pub fn parse_pyproject(path: &Path) -> Vec<DeclaredDependency> {
 }
 
 /// Parses a requirements.txt file and extracts declared dependencies.
+///
+/// `-r other.txt` / `--requirement other.txt` include directives are followed
+/// relative to the including file, as pip does.
 pub fn parse_requirements(path: &Path) -> Vec<DeclaredDependency> {
+    let mut visited = Vec::new();
+    parse_requirements_inner(path, &mut visited)
+}
+
+/// Extracts the target of an `-r` / `--requirement` include directive.
+fn requirement_include_target(line: &str) -> Option<&str> {
+    let rest = line
+        .strip_prefix("--requirement")
+        .or_else(|| line.strip_prefix("-r"))?;
+    let rest = rest.trim_start_matches(['=', ' ', '\t']).trim();
+    (!rest.is_empty() && !rest.starts_with('-')).then_some(rest)
+}
+
+fn parse_requirements_inner(path: &Path, visited: &mut Vec<PathBuf>) -> Vec<DeclaredDependency> {
     let mut deps = Vec::new();
+
+    // Guard against `-r` include cycles.
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    if visited.contains(&canonical) {
+        return deps;
+    }
+    visited.push(canonical);
+
     let filename = path
         .file_name()
         .unwrap_or_default()
         .to_string_lossy()
         .to_string();
+    let is_dev = filename.contains("dev") || filename.contains("test");
 
-    if let Ok(content) = std::fs::read_to_string(path) {
-        for line in content.lines() {
-            let line = line.trim();
-            if line.is_empty() || line.starts_with('#') || line.starts_with('-') {
-                continue;
-            }
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return deps;
+    };
 
-            if let Some((pkg, marker)) = extract_pep508_parts(line) {
-                deps.push(DeclaredDependency {
-                    package_name: pkg.clone(),
-                    normalized_name: normalize_package_name(&pkg),
-                    is_dev: filename.contains("dev") || filename.contains("test"),
-                    is_optional: false,
-                    marker,
-                    source: DependencySource::Requirements(filename.clone()),
-                });
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if line.starts_with('-') {
+            if let Some(target) = requirement_include_target(line) {
+                let base = path.parent().unwrap_or_else(|| Path::new("."));
+                deps.extend(parse_requirements_inner(&base.join(target), visited));
             }
+            continue;
+        }
+
+        if let Some((pkg, marker)) = extract_pep508_parts(line) {
+            deps.push(DeclaredDependency {
+                package_name: pkg.clone(),
+                normalized_name: normalize_package_name(&pkg),
+                is_dev,
+                is_optional: false,
+                marker,
+                source: DependencySource::Requirements(filename.clone()),
+            });
         }
     }
 
     deps
+}
+
+/// Walks up from `start` to find the directory holding the project's dependency
+/// manifest, so that analyzing a subdirectory (`cytoscnpy deps src/`) still sees
+/// the declarations. Stops at a `.git` boundary and falls back to `start`.
+pub fn find_project_root(start: &Path) -> PathBuf {
+    const MANIFESTS: &[&str] = &[
+        "pyproject.toml",
+        "requirements.txt",
+        "setup.cfg",
+        "setup.py",
+    ];
+
+    let mut current = Some(start);
+    while let Some(dir) = current {
+        if MANIFESTS.iter().any(|name| dir.join(name).exists()) {
+            return dir.to_path_buf();
+        }
+        if dir != start && dir.join(".git").exists() {
+            break;
+        }
+        current = dir.parent();
+    }
+    start.to_path_buf()
 }
 
 /// Locates and parses dependency declarations from pyproject.toml or a provided requirements file.
@@ -226,6 +287,18 @@ pub fn locate_and_parse_declarations(
     let pyproject = root.join("pyproject.toml");
     if pyproject.exists() {
         all_deps.extend(parse_pyproject(&pyproject));
+    }
+
+    // Pre-PEP-621 setuptools projects declare their dependencies in setup.cfg or
+    // setup.py. Both can coexist with a pyproject.toml that only carries build
+    // configuration, so they are read regardless of whether pyproject.toml exists.
+    let setup_cfg = root.join("setup.cfg");
+    if setup_cfg.exists() {
+        all_deps.extend(super::setup::parse_setup_cfg(&setup_cfg));
+    }
+    let setup_py = root.join("setup.py");
+    if setup_py.exists() {
+        all_deps.extend(super::setup::parse_setup_py(&setup_py));
     }
 
     // Then optionally explicit requirements file, or fallback to auto-discover
@@ -245,6 +318,18 @@ pub fn locate_and_parse_declarations(
             all_deps.extend(parse_requirements(&dev_req_txt));
         }
     }
+
+    // `-r` includes and overlapping auto-discovered files can yield the same
+    // declaration twice; keep the first occurrence of each.
+    let mut seen = std::collections::HashSet::new();
+    all_deps.retain(|dep| {
+        seen.insert((
+            dep.normalized_name.clone(),
+            dep.is_dev,
+            dep.is_optional,
+            dep.source.clone(),
+        ))
+    });
 
     all_deps
 }

--- a/cytoscnpy/src/deps/declared_tests.rs
+++ b/cytoscnpy/src/deps/declared_tests.rs
@@ -132,6 +132,105 @@ dev = [
 }
 
 #[test]
+fn test_parse_pyproject_poetry_and_pdm_layouts() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let pyproject_path = dir.path().join("pyproject.toml");
+    fs::write(
+        &pyproject_path,
+        r#"
+[tool.poetry.dependencies]
+python = "^3.10"
+requests = "^2.28"
+
+[tool.poetry.dev-dependencies]
+black = "^24.0"
+
+[tool.poetry.group.test.dependencies]
+pytest = "^8.0"
+
+[tool.pdm.dev-dependencies]
+lint = ["ruff"]
+"#,
+    )?;
+
+    let deps = parse_pyproject(&pyproject_path);
+    let dep = |name: &str| deps.iter().find(|d| d.package_name == name);
+
+    assert!(
+        dep("python").is_none(),
+        "the python constraint is not a dependency"
+    );
+    assert!(!dep("requests").expect("poetry runtime dep").is_dev);
+    assert!(dep("black").expect("poetry dev-dependencies").is_dev);
+    assert!(dep("pytest").expect("poetry group dependencies").is_dev);
+    assert!(dep("lint").expect("pdm dev-dependency group").is_dev);
+    Ok(())
+}
+
+#[test]
+fn test_parse_pyproject_ignores_malformed_and_missing_files() {
+    let dir = tempdir().expect("tempdir");
+    let missing = dir.path().join("nope.toml");
+    assert!(parse_pyproject(&missing).is_empty());
+
+    let broken = dir.path().join("pyproject.toml");
+    fs::write(&broken, "[project\ndependencies = [").expect("write");
+    assert!(parse_pyproject(&broken).is_empty());
+}
+
+#[test]
+fn test_find_project_root_walks_up_to_the_manifest() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path();
+    fs::write(root.join("pyproject.toml"), "[project]\n")?;
+    let nested = root.join("src").join("pkg");
+    fs::create_dir_all(&nested)?;
+
+    assert_eq!(
+        find_project_root(&nested).canonicalize()?,
+        root.canonicalize()?
+    );
+    assert_eq!(
+        find_project_root(root).canonicalize()?,
+        root.canonicalize()?
+    );
+    Ok(())
+}
+
+#[test]
+fn test_find_project_root_falls_back_to_the_start_directory() -> anyhow::Result<()> {
+    // No manifest anywhere, and a `.git` boundary stops the upward walk.
+    let dir = tempdir()?;
+    fs::create_dir_all(dir.path().join(".git"))?;
+    let nested = dir.path().join("a").join("b");
+    fs::create_dir_all(&nested)?;
+
+    assert_eq!(find_project_root(&nested), nested);
+    Ok(())
+}
+
+#[test]
+fn test_parse_requirements_follows_includes() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    fs::create_dir_all(dir.path().join("reqs"))?;
+    fs::write(dir.path().join("reqs").join("base.txt"), "requests\n")?;
+    fs::write(
+        dir.path().join("requirements.txt"),
+        "--requirement reqs/base.txt\n-r reqs/base.txt\n-e .\n--index-url https://example.invalid\nnumpy\n",
+    )?;
+
+    let deps = parse_requirements(&dir.path().join("requirements.txt"));
+    let names: Vec<&str> = deps.iter().map(|d| d.package_name.as_str()).collect();
+
+    assert_eq!(
+        names,
+        vec!["requests", "numpy"],
+        "includes are followed once; -e and option flags are skipped"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_parse_requirements_basics() -> anyhow::Result<()> {
     let dir = tempdir()?;
     let req_path = dir.path().join("requirements.txt");

--- a/cytoscnpy/src/deps/imports.rs
+++ b/cytoscnpy/src/deps/imports.rs
@@ -32,18 +32,44 @@ pub struct ImportScan {
     pub all: FxHashSet<String>,
     /// Imports found in files classified as production code.
     pub production: FxHashSet<String>,
+    /// Imports that appear only inside `if TYPE_CHECKING:` blocks. These are not
+    /// runtime imports, so they must not create "missing dependency" findings, but
+    /// they do keep a declared dependency from being reported as unused.
+    pub type_checking: FxHashSet<String>,
     /// Source evidence for every import occurrence.
     pub occurrences: Vec<ImportOccurrence>,
+}
+
+impl ImportScan {
+    fn empty() -> Self {
+        Self {
+            all: FxHashSet::default(),
+            production: FxHashSet::default(),
+            type_checking: FxHashSet::default(),
+            occurrences: Vec::new(),
+        }
+    }
 }
 
 fn is_test_or_dev_file(file: &std::path::Path) -> bool {
     crate::utils::is_test_path(&file.to_string_lossy())
 }
 
+/// A top-level `setup.py` is a build script, not importable source: what it
+/// imports (`setuptools`, `distutils`) are build requirements rather than
+/// dependencies of the project, so it must not drive dependency findings.
+fn is_build_script(file: &std::path::Path, roots: &[PathBuf]) -> bool {
+    file.file_name().is_some_and(|name| name == "setup.py")
+        && file
+            .parent()
+            .is_some_and(|parent| roots.iter().any(|root| root == parent))
+}
+
 /// Scans Python files and returns import names split by all files and
 /// production files. Test/dev files are excluded only from the production set.
 pub fn extract_import_scan(roots: &[PathBuf], exclude: &[String], verbose: bool) -> ImportScan {
-    let files = find_python_files(roots, exclude, verbose);
+    let mut files = find_python_files(roots, exclude, verbose);
+    files.retain(|file| !is_build_script(file, roots));
 
     files
         .into_par_iter()
@@ -51,19 +77,13 @@ pub fn extract_import_scan(roots: &[PathBuf], exclude: &[String], verbose: bool)
             let is_production = !is_test_or_dev_file(&file);
             extract_imports_from_file(&file, is_production)
         })
-        .reduce(
-            || ImportScan {
-                all: FxHashSet::default(),
-                production: FxHashSet::default(),
-                occurrences: Vec::new(),
-            },
-            |mut acc, scan| {
-                acc.all.extend(scan.all);
-                acc.production.extend(scan.production);
-                acc.occurrences.extend(scan.occurrences);
-                acc
-            },
-        )
+        .reduce(ImportScan::empty, |mut acc, scan| {
+            acc.all.extend(scan.all);
+            acc.production.extend(scan.production);
+            acc.type_checking.extend(scan.type_checking);
+            acc.occurrences.extend(scan.occurrences);
+            acc
+        })
 }
 
 /// Scans Python files within the provided roots and extracts all import names,

--- a/cytoscnpy/src/deps/imports.rs
+++ b/cytoscnpy/src/deps/imports.rs
@@ -62,7 +62,20 @@ fn is_build_script(file: &std::path::Path, roots: &[PathBuf]) -> bool {
     file.file_name().is_some_and(|name| name == "setup.py")
         && file
             .parent()
-            .is_some_and(|parent| roots.iter().any(|root| root == parent))
+            .is_some_and(|parent| roots.iter().any(|root| same_dir(root, parent)))
+}
+
+/// Compares two directory paths without touching the filesystem. An empty path
+/// and `.` both mean the current directory but are not equal as `Path` values.
+fn same_dir(a: &std::path::Path, b: &std::path::Path) -> bool {
+    fn as_current_dir(path: &std::path::Path) -> &std::path::Path {
+        if path.as_os_str().is_empty() {
+            std::path::Path::new(".")
+        } else {
+            path
+        }
+    }
+    as_current_dir(a) == as_current_dir(b)
 }
 
 /// Scans Python files and returns import names split by all files and

--- a/cytoscnpy/src/deps/imports_collect.rs
+++ b/cytoscnpy/src/deps/imports_collect.rs
@@ -85,7 +85,8 @@ fn collect_imports(
                     }
                 }
             }
-            // Relative imports (`from . import x`) never name a distribution.
+            // Only absolute imports (level 0) can name a distribution; relative
+            // imports (`from . import x`) are handled by the arm below.
             Stmt::ImportFrom(import_from) if import_from.level == 0 => {
                 aliases.record_import_from(import_from);
                 let Some(top_level) = import_from

--- a/cytoscnpy/src/deps/imports_collect.rs
+++ b/cytoscnpy/src/deps/imports_collect.rs
@@ -11,6 +11,7 @@ pub(super) fn extract_imports_from_file(file: &std::path::Path, is_production: b
     let mut scan = ImportScan {
         all: FxHashSet::default(),
         production: FxHashSet::default(),
+        type_checking: FxHashSet::default(),
         occurrences: Vec::new(),
     };
     if let Ok(content) = std::fs::read_to_string(file) {
@@ -60,31 +61,18 @@ fn collect_imports(
         match stmt {
             Stmt::Import(import_stmt) => {
                 aliases.record_import(import_stmt);
-                if !in_type_checking_block {
+                let names = import_stmt
+                    .names
+                    .iter()
+                    .filter_map(|alias| alias.name.split('.').next());
+                if in_type_checking_block {
+                    scan.type_checking
+                        .extend(names.map(std::borrow::ToOwned::to_owned));
+                } else {
                     dynamic_aliases.record_import(import_stmt);
                     let mut recorded = FxHashSet::default();
-                    for alias in &import_stmt.names {
-                        if let Some(top_level) = alias.name.split('.').next() {
-                            if recorded.insert(top_level) {
-                                add_import_occurrence(
-                                    scan,
-                                    top_level,
-                                    stmt,
-                                    file,
-                                    line_index,
-                                    is_production,
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-            Stmt::ImportFrom(import_from) => {
-                aliases.record_import_from(import_from);
-                if !in_type_checking_block && import_from.level == 0 {
-                    dynamic_aliases.record_import_from(import_from);
-                    if let Some(module) = &import_from.module {
-                        if let Some(top_level) = module.as_ref().split('.').next() {
+                    for top_level in names {
+                        if recorded.insert(top_level) {
                             add_import_occurrence(
                                 scan,
                                 top_level,
@@ -97,6 +85,24 @@ fn collect_imports(
                     }
                 }
             }
+            // Relative imports (`from . import x`) never name a distribution.
+            Stmt::ImportFrom(import_from) if import_from.level == 0 => {
+                aliases.record_import_from(import_from);
+                let Some(top_level) = import_from
+                    .module
+                    .as_ref()
+                    .and_then(|module| module.as_ref().split('.').next())
+                else {
+                    continue;
+                };
+                if in_type_checking_block {
+                    scan.type_checking.insert(top_level.to_owned());
+                } else {
+                    dynamic_aliases.record_import_from(import_from);
+                    add_import_occurrence(scan, top_level, stmt, file, line_index, is_production);
+                }
+            }
+            Stmt::ImportFrom(import_from) => aliases.record_import_from(import_from),
             Stmt::FunctionDef(f) => {
                 collect_imports(
                     &f.body,

--- a/cytoscnpy/src/deps/installed.rs
+++ b/cytoscnpy/src/deps/installed.rs
@@ -14,6 +14,10 @@ pub struct InstalledPackage {
     pub version: String,
     /// Direct runtime dependencies as normalized names.
     pub requires: Vec<String>,
+    /// Top-level import names the distribution provides, read from the
+    /// `top_level.txt` of its `.dist-info`. Empty when the file is absent.
+    #[serde(default)]
+    pub top_level: Vec<String>,
 }
 
 /// Parses a single `METADATA` file and extracts the package name, version,
@@ -48,7 +52,25 @@ fn parse_metadata(content: &str) -> Option<InstalledPackage> {
         normalized_name,
         version,
         requires,
+        top_level: Vec::new(),
     })
+}
+
+/// Reads the top-level import names a distribution provides from its
+/// `top_level.txt`. This is authoritative: it is what the installer recorded,
+/// not a guess from the distribution name.
+fn parse_top_level(dist_info: &Path) -> Vec<String> {
+    let Ok(content) = std::fs::read_to_string(dist_info.join("top_level.txt")) else {
+        return Vec::new();
+    };
+    content
+        .lines()
+        .map(str::trim)
+        // Namespace dists record `google/cloud`-style paths; only the root is an import.
+        .filter_map(|line| line.split(['/', '\\']).next())
+        .filter(|name| !name.is_empty())
+        .map(std::borrow::ToOwned::to_owned)
+        .collect()
 }
 
 /// Finds the `site-packages` directory inside a `.venv`.
@@ -113,7 +135,8 @@ pub fn scan_installed(venv_root: &Path) -> FxHashMap<String, InstalledPackage> {
             continue;
         };
 
-        if let Some(pkg) = parse_metadata(&content) {
+        if let Some(mut pkg) = parse_metadata(&content) {
+            pkg.top_level = parse_top_level(&path);
             result.insert(pkg.normalized_name.clone(), pkg);
         }
     }
@@ -166,6 +189,34 @@ mod tests {
             .requires
             .contains(&"urllib3".to_owned()));
         assert!(installed.contains_key("urllib3"));
+    }
+
+    #[test]
+    fn test_scan_installed_reads_top_level_import_names() {
+        let tmp = tempdir().unwrap();
+        let venv = tmp.path().join(".venv");
+        let site_pkg = venv.join("Lib").join("site-packages");
+        fs::create_dir_all(&site_pkg).unwrap();
+
+        make_dist_info(&site_pkg, "pyyaml", "6.0", &[]);
+        make_dist_info(&site_pkg, "plain", "1.0", &[]);
+        fs::write(
+            site_pkg.join("pyyaml-6.0.dist-info").join("top_level.txt"),
+            // Namespace dists record paths; blank lines are common.
+            "yaml\n_yaml\ngoogle/cloud\n\n",
+        )
+        .unwrap();
+
+        let installed = scan_installed(&venv);
+        assert_eq!(
+            installed["pyyaml"].top_level,
+            vec!["yaml".to_owned(), "_yaml".to_owned(), "google".to_owned()],
+            "only the import root of a namespace path is an import name"
+        );
+        assert!(
+            installed["plain"].top_level.is_empty(),
+            "a distribution without top_level.txt records no import names"
+        );
     }
 
     #[test]

--- a/cytoscnpy/src/deps/lockfile.rs
+++ b/cytoscnpy/src/deps/lockfile.rs
@@ -320,6 +320,48 @@ mod tests {
     }
 
     #[test]
+    fn test_load_lockfile_graph_at_explicit_path() {
+        let tmp = tempdir().unwrap();
+
+        let uv = tmp.path().join("uv.lock");
+        fs::write(&uv, uv_lock_sample()).unwrap();
+        let graph = load_lockfile_graph_at(&uv).expect("uv.lock parses");
+        assert!(graph.forward.contains_key("requests"));
+
+        // Recognized by file name, not by content.
+        let unknown = tmp.path().join("Pipfile.lock");
+        fs::write(&unknown, uv_lock_sample()).unwrap();
+        assert!(load_lockfile_graph_at(&unknown).is_none());
+
+        // A lockfile with no packages yields no graph.
+        let empty = tmp.path().join("empty").join("poetry.lock");
+        fs::create_dir_all(empty.parent().unwrap()).unwrap();
+        fs::write(&empty, "").unwrap();
+        assert!(load_lockfile_graph_at(&empty).is_none());
+
+        assert!(load_lockfile_graph_at(&tmp.path().join("absent.lock")).is_none());
+    }
+
+    #[test]
+    fn test_load_lockfile_graph_prefers_uv_then_poetry() {
+        let tmp = tempdir().unwrap();
+        assert!(load_lockfile_graph(tmp.path()).is_none());
+
+        fs::write(
+            tmp.path().join("poetry.lock"),
+            "[[package]]\nname = \"certifi\"\nversion = \"1.0\"\n",
+        )
+        .unwrap();
+        let graph =
+            load_lockfile_graph(tmp.path()).expect("poetry.lock is used when uv.lock is absent");
+        assert!(graph.forward.contains_key("certifi"));
+
+        fs::write(tmp.path().join("uv.lock"), uv_lock_sample()).unwrap();
+        let graph = load_lockfile_graph(tmp.path()).expect("uv.lock wins");
+        assert!(graph.forward.contains_key("requests"));
+    }
+
+    #[test]
     fn test_load_lockfile_graph_from_temp_dir() {
         let tmp = tempdir().unwrap();
         fs::write(tmp.path().join("uv.lock"), uv_lock_sample()).unwrap();

--- a/cytoscnpy/src/deps/mod.rs
+++ b/cytoscnpy/src/deps/mod.rs
@@ -10,8 +10,14 @@ pub mod installed;
 pub mod lockfile;
 /// Package-to-import mapping definitions.
 pub mod mapping;
+/// Parsers for the setuptools declaration files (setup.py / setup.cfg).
+pub mod setup;
 /// Standard library reference list.
 pub mod stdlib;
+
+#[cfg(test)]
+#[path = "analysis_tests.rs"]
+mod analysis_tests;
 
 pub use analysis::{
     analyze_dependencies, DependencyImportLocation, DepsOptions, DepsResult,

--- a/cytoscnpy/src/deps/setup.rs
+++ b/cytoscnpy/src/deps/setup.rs
@@ -1,0 +1,201 @@
+//! Dependency declarations from the pre-PEP-621 setuptools files: `setup.py`
+//! and `setup.cfg`.
+//!
+//! Only literal declarations can be recovered. A `setup.py` that computes its
+//! requirements at runtime (reading a file, building a list in a loop) yields
+//! nothing here, because evaluating it would mean executing arbitrary code.
+
+use super::declared::{extract_pep508_parts, normalize_package_name, DeclaredDependency};
+use super::DependencySource;
+use ruff_python_ast::visitor::{self, Visitor};
+use ruff_python_ast::{self as ast, Expr};
+use ruff_python_parser::parse_module;
+use std::path::Path;
+
+/// Keyword arguments of `setup()` that hold requirement lists, and whether the
+/// requirements they hold are development-only.
+const SETUP_LIST_KEYWORDS: &[(&str, bool)] = &[
+    ("install_requires", false),
+    ("setup_requires", true),
+    ("tests_require", true),
+];
+
+fn make_dep(
+    spec: &str,
+    source: &DependencySource,
+    is_dev: bool,
+    is_optional: bool,
+) -> Option<DeclaredDependency> {
+    let (package_name, marker) = extract_pep508_parts(spec)?;
+    Some(DeclaredDependency {
+        normalized_name: normalize_package_name(&package_name),
+        package_name,
+        is_dev,
+        is_optional,
+        marker,
+        source: source.clone(),
+    })
+}
+
+// ──────────────────────────────────────────────────────────────
+// setup.py
+// ──────────────────────────────────────────────────────────────
+
+/// Extracts requirements from the literal keyword arguments of a `setup()` call.
+pub fn parse_setup_py(path: &Path) -> Vec<DeclaredDependency> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let Ok(parsed) = parse_module(&content) else {
+        return Vec::new();
+    };
+
+    let mut collector = SetupCallCollector { deps: Vec::new() };
+    for stmt in &parsed.into_syntax().body {
+        collector.visit_stmt(stmt);
+    }
+    collector.deps
+}
+
+struct SetupCallCollector {
+    deps: Vec<DeclaredDependency>,
+}
+
+impl Visitor<'_> for SetupCallCollector {
+    fn visit_expr(&mut self, expr: &Expr) {
+        if let Expr::Call(call) = expr {
+            if is_setup_call(&call.func) {
+                self.collect_setup_arguments(&call.arguments);
+            }
+        }
+        visitor::walk_expr(self, expr);
+    }
+}
+
+/// Matches both `setup(...)` and `setuptools.setup(...)` / `distutils.core.setup(...)`.
+fn is_setup_call(func: &Expr) -> bool {
+    match func {
+        Expr::Name(name) => name.id.as_str() == "setup",
+        Expr::Attribute(attr) => attr.attr.as_str() == "setup",
+        _ => false,
+    }
+}
+
+impl SetupCallCollector {
+    fn collect_setup_arguments(&mut self, arguments: &ast::Arguments) {
+        let source = DependencySource::Setup("setup.py".to_owned());
+        for keyword in &arguments.keywords {
+            let Some(name) = keyword.arg.as_ref().map(ast::Identifier::as_str) else {
+                continue;
+            };
+
+            if let Some((_, is_dev)) = SETUP_LIST_KEYWORDS.iter().find(|(kw, _)| *kw == name) {
+                self.deps.extend(
+                    string_list(&keyword.value)
+                        .filter_map(|spec| make_dep(spec, &source, *is_dev, false)),
+                );
+            } else if name == "extras_require" {
+                let Expr::Dict(dict) = &keyword.value else {
+                    continue;
+                };
+                for item in &dict.items {
+                    self.deps.extend(
+                        string_list(&item.value)
+                            .filter_map(|spec| make_dep(spec, &source, false, true)),
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// The string literals of a list/tuple expression; empty for anything else.
+fn string_list(expr: &Expr) -> impl Iterator<Item = &str> {
+    let elements: &[Expr] = match expr {
+        Expr::List(list) => &list.elts,
+        Expr::Tuple(tuple) => &tuple.elts,
+        _ => &[],
+    };
+    elements.iter().filter_map(|element| match element {
+        Expr::StringLiteral(literal) => Some(literal.value.to_str()),
+        _ => None,
+    })
+}
+
+// ──────────────────────────────────────────────────────────────
+// setup.cfg
+// ──────────────────────────────────────────────────────────────
+
+/// Whether a `section = key` pair in `setup.cfg` holds requirements, and if so
+/// whether they are optional (an extra). In `[options]` only `install_requires`
+/// does; in `[options.extras_require]` every key names an extra.
+fn requirement_key_is_optional(section: &str, key: &str) -> Option<bool> {
+    match section {
+        "options" if key == "install_requires" => Some(false),
+        "options.extras_require" => Some(true),
+        _ => None,
+    }
+}
+
+/// Extracts requirements from `[options] install_requires` and
+/// `[options.extras_require]` in a `setup.cfg`.
+pub fn parse_setup_cfg(path: &Path) -> Vec<DeclaredDependency> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let source = DependencySource::Setup("setup.cfg".to_owned());
+
+    let mut deps = Vec::new();
+    let mut section = String::new();
+    // Set while reading the indented continuation lines of a requirement key;
+    // holds whether those requirements are optional.
+    let mut continuing: Option<bool> = None;
+
+    for raw_line in content.lines() {
+        let line = raw_line.split('#').next().unwrap_or(raw_line);
+        let trimmed = line.trim();
+
+        if let Some(name) = trimmed.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            name.trim().clone_into(&mut section);
+            continuing = None;
+            continue;
+        }
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        // An indented line continues the value of the preceding key.
+        if raw_line.starts_with([' ', '\t']) {
+            if let Some(is_optional) = continuing {
+                deps.extend(make_dep(trimmed, &source, false, is_optional));
+            }
+            continue;
+        }
+
+        continuing = None;
+        let Some((key, value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        let Some(is_optional) = requirement_key_is_optional(&section, key.trim()) else {
+            continue;
+        };
+
+        // Either `key = a, b` on one line, or `key =` with indented entries below.
+        let value = value.trim();
+        if value.is_empty() {
+            continuing = Some(is_optional);
+        } else {
+            deps.extend(
+                value
+                    .split(',')
+                    .filter_map(|spec| make_dep(spec, &source, false, is_optional)),
+            );
+        }
+    }
+
+    deps
+}
+
+#[cfg(test)]
+#[path = "setup_tests.rs"]
+mod tests;

--- a/cytoscnpy/src/deps/setup_tests.rs
+++ b/cytoscnpy/src/deps/setup_tests.rs
@@ -1,0 +1,126 @@
+use super::*;
+use std::fs;
+use tempfile::{tempdir, TempDir};
+
+fn write_file(name: &str, content: &str) -> (TempDir, std::path::PathBuf) {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join(name);
+    fs::write(&path, content).expect("write");
+    (dir, path)
+}
+
+fn summarize(deps: &[DeclaredDependency]) -> Vec<(&str, bool, bool)> {
+    deps.iter()
+        .map(|dep| (dep.package_name.as_str(), dep.is_dev, dep.is_optional))
+        .collect()
+}
+
+#[test]
+fn setup_py_install_requires_extras_and_test_requirements() {
+    let (_dir, path) = write_file(
+        "setup.py",
+        "from setuptools import setup\n\
+         setup(\n\
+             name='proj',\n\
+             install_requires=['requests>=2.0', 'flask'],\n\
+             tests_require=('pytest',),\n\
+             extras_require={'docs': ['sphinx'], 'all': ['rich']},\n\
+         )\n",
+    );
+
+    let deps = parse_setup_py(&path);
+    let mut found = summarize(&deps);
+    found.sort_unstable();
+
+    assert_eq!(
+        found,
+        vec![
+            ("flask", false, false),
+            ("pytest", true, false),
+            ("requests", false, false),
+            ("rich", false, true),
+            ("sphinx", false, true),
+        ]
+    );
+    assert_eq!(
+        deps[0].source,
+        DependencySource::Setup("setup.py".to_owned())
+    );
+}
+
+#[test]
+fn setup_py_qualified_call_and_nested_position_are_found() {
+    let (_dir, path) = write_file(
+        "setup.py",
+        "import setuptools\n\
+         def main():\n    \
+             setuptools.setup(install_requires=['requests'])\n\
+         if __name__ == '__main__':\n    main()\n",
+    );
+
+    assert_eq!(
+        summarize(&parse_setup_py(&path)),
+        vec![("requests", false, false)]
+    );
+}
+
+#[test]
+fn setup_py_non_literal_requirements_are_skipped_not_guessed() {
+    let (_dir, path) = write_file(
+        "setup.py",
+        "from setuptools import setup\n\
+         reqs = open('requirements.txt').read().splitlines()\n\
+         setup(install_requires=reqs, extras_require={'x': reqs})\n",
+    );
+
+    assert!(
+        parse_setup_py(&path).is_empty(),
+        "a computed requirement list cannot be recovered without executing the file"
+    );
+}
+
+#[test]
+fn setup_py_that_does_not_parse_yields_nothing() {
+    let (_dir, path) = write_file("setup.py", "setup(install_requires=[");
+    assert!(parse_setup_py(&path).is_empty());
+    assert!(parse_setup_py(std::path::Path::new("no/such/setup.py")).is_empty());
+}
+
+#[test]
+fn setup_cfg_indented_and_inline_requirement_lists() {
+    let (_dir, path) = write_file(
+        "setup.cfg",
+        "[metadata]\nname = proj\ninstall_requires = ignored\n\n\
+         [options]\n\
+         python_requires = >=3.10\n\
+         install_requires =\n    \
+             requests>=2.0  # http\n    \
+             flask\n\n\
+         [options.extras_require]\n\
+         docs = sphinx, myst-parser\n\
+         test =\n    pytest\n",
+    );
+
+    let deps = parse_setup_cfg(&path);
+    let mut found = summarize(&deps);
+    found.sort_unstable();
+
+    assert_eq!(
+        found,
+        vec![
+            ("flask", false, false),
+            ("myst-parser", false, true),
+            ("pytest", false, true),
+            ("requests", false, false),
+            ("sphinx", false, true),
+        ],
+        "`install_requires` outside [options] and `python_requires` are not dependencies"
+    );
+}
+
+#[test]
+fn setup_cfg_that_declares_nothing_yields_nothing() {
+    let (_dir, path) = write_file("setup.cfg", "[metadata]\nname = proj\n");
+    assert!(parse_setup_cfg(&path).is_empty());
+    assert!(parse_setup_cfg(std::path::Path::new("no/such/setup.cfg")).is_empty());
+}

--- a/cytoscnpy/src/entry_point/handlers/analysis/run.rs
+++ b/cytoscnpy/src/entry_point/handlers/analysis/run.rs
@@ -133,7 +133,12 @@ pub(crate) fn run_analysis<W: std::io::Write>(
         .clone_similarity
         .or(config.cytoscnpy.clone_similarity)
         .unwrap_or(0.8);
-    if cli_var.clones || clones_from_config || cli_var.output.html {
+    #[cfg(feature = "html_report")]
+    let html_output_requested = cli_var.output.html;
+    #[cfg(not(feature = "html_report"))]
+    let html_output_requested = false;
+
+    if cli_var.clones || clones_from_config || html_output_requested {
         clone_similarity_used = Some(clone_similarity);
         let clone_options = crate::commands::CloneOptions {
             similarity: clone_similarity,

--- a/cytoscnpy/src/output/tables.rs
+++ b/cytoscnpy/src/output/tables.rs
@@ -217,7 +217,8 @@ pub fn print_unused_dependencies(
     for dep in dependencies {
         let source_str = match &dep.source {
             crate::deps::DependencySource::Pyproject => "pyproject.toml".to_owned(),
-            crate::deps::DependencySource::Requirements(f) => f.clone(),
+            crate::deps::DependencySource::Requirements(f)
+            | crate::deps::DependencySource::Setup(f) => f.clone(),
         };
         let dev_str = if dep.is_dev { "dev" } else { "prod" };
         table.add_row(vec![

--- a/cytoscnpy/src/report/mod.rs
+++ b/cytoscnpy/src/report/mod.rs
@@ -23,9 +23,3 @@ pub mod junit;
 pub mod markdown;
 /// SARIF report generator.
 pub mod sarif;
-
-// Public API re-exports or stubs if needed when feature is disabled
-#[cfg(not(feature = "html_report"))]
-pub mod generator {
-    // Stub or empty module
-}

--- a/cytoscnpy/tests/deps_test.rs
+++ b/cytoscnpy/tests/deps_test.rs
@@ -540,6 +540,10 @@ dev = ["nox"]
     Ok(())
 }
 
+/// A `TYPE_CHECKING` import is not a runtime import, so it never makes a
+/// dependency missing, and a dev dependency used only for typing is not a dev
+/// dependency used in production. It is still a *use* of the package though:
+/// deleting `pydantic` here would break type checking, so it is not unused.
 #[test]
 fn test_deps_type_checking_imports_do_not_count_as_runtime() -> anyhow::Result<()> {
     let dir = tempdir()?;
@@ -566,11 +570,9 @@ dev = ["pytest"]
         run_deps_command(vec!["deps".to_owned(), root.to_string_lossy().into_owned()]);
 
     assert_eq!(code, 0);
-    assert!(output.contains("Unused Dependencies (CSP-R002)"));
-    assert!(output.contains("pydantic"));
+    assert!(!output.contains("Unused Dependencies (CSP-R002)"));
     assert!(!output.contains("Missing Dependencies (CSP-R001)"));
     assert!(!output.contains("Development Dependency Used in Production (CSP-R004)"));
-    assert!(!output.contains("pytest"));
     Ok(())
 }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -253,8 +253,6 @@ include_folders = ["src"]
 
 # Rule suppression
 ignore = ["CSP-P003"]      # Globally ignore specific rule IDs
-per-file-ignores = { "tests/*" = ["CSP-D701"], "**/__init__.py" = ["CSP-L001"] }
-# Glob behavior: "*" matches a single path segment, "**" matches recursively.
 
 # Clone detection
 clones = false             # Enable duplicate code detection
@@ -265,11 +263,34 @@ fail_threshold = 5.0
 fail_on_secrets = true
 fail_on_danger = true
 
-# Inline whitelist (suppress specific dead-code symbols)
+# Per-file rule suppressions (glob -> rule IDs).
+# Use a real table (not an inline `{ ... }`) so entries can span multiple
+# lines without tripping TOML/editor syntax errors.
+# Glob behavior: "*" matches a single path segment, "**" matches recursively.
+[cytoscnpy.per-file-ignores]
+"tests/*" = ["CSP-D701"]
+"**/__init__.py" = ["CSP-L001"]
+
+# Inline whitelist (suppress specific dead-code symbols).
+# One array, one entry per line — no repeated headers needed.
+whitelist = [
+  { name = "my_handler" },                              # "exact" match (default)
+  { name = "another_symbol", pattern = "wildcard" },     # "exact", "wildcard", or "regex"
+  { name = "legacy_fn", file = "src/api/*.py" },         # optional: restrict to a file glob
+]
+```
+
+Prefer `[[cytoscnpy.whitelist]]` blocks instead if you want to attach a comment
+above each entry:
+
+```toml
 [[cytoscnpy.whitelist]]
 name = "my_handler"
-pattern = "exact"          # "exact" (default), "wildcard", or "regex"
-# file = "src/api/*.py"    # Optional: restrict to a specific file glob
+pattern = "exact"
+
+[[cytoscnpy.whitelist]]
+name = "another_symbol"
+pattern = "wildcard"
 ```
 
 ### Advanced Configuration

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -273,7 +273,6 @@ quality = true
 include_ipynb = false
 project_type = "library"   # "library" (default) or "application"
 ignore = ["CSP-P003"]      # Global rule suppressions
-per-file-ignores = { "tests/*" = ["CSP-D701"] }
 
 # Clone detection
 clones = false             # Enable duplicate code detection
@@ -285,6 +284,13 @@ max_complexity = 15    # Function CC > 15
 min_mi = 40.0          # MI < 40
 fail_on_secrets = true # Any secret finding
 fail_on_danger = true  # Any danger or taint finding
+
+# Per-file rule suppressions (glob -> rule IDs). Must be its own table
+# (not an inline `{ ... }`) so entries can span multiple lines without
+# TOML syntax errors.
+[cytoscnpy.per-file-ignores]
+"tests/*" = ["CSP-D701"]
+"**/__init__.py" = ["CSP-L001"]
 ```
 
 ### Option 2: `pyproject.toml`
@@ -300,7 +306,6 @@ danger = true
 quality = true
 project_type = "library"
 ignore = ["CSP-P003"]
-per-file-ignores = { "tests/*" = ["CSP-D701"] }
 
 # Clone detection
 clones = false
@@ -312,6 +317,13 @@ max_complexity = 15
 min_mi = 40.0
 fail_on_secrets = true
 fail_on_danger = true
+
+# Per-file rule suppressions (glob -> rule IDs). Must be its own table
+# (not an inline `{ ... }`) so entries can span multiple lines without
+# TOML syntax errors.
+[tool.cytoscnpy.per-file-ignores]
+"tests/*" = ["CSP-D701"]
+"**/__init__.py" = ["CSP-L001"]
 ```
 
 ### Advanced Config (Security)

--- a/editors/vscode/cytoscnpy/package-lock.json
+++ b/editors/vscode/cytoscnpy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cytoscnpy",
-  "version": "1.2.24",
+  "version": "1.2.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cytoscnpy",
-      "version": "1.2.24",
+      "version": "1.2.26",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/editors/vscode/cytoscnpy/package.json
+++ b/editors/vscode/cytoscnpy/package.json
@@ -3,7 +3,7 @@
   "publisher": "djinn09",
   "displayName": "CytoScnPy",
   "description": "Python static analyzer with MCP server for GitHub Copilot. Real-time dead code detection, security scanning, and code quality metrics.",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "icon": "assets/icon.png",
   "repository": {
     "type": "git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,3 +368,146 @@ exclude = [
 venvPath = "."
 venv = ".venv"
 pythonVersion = "3.10"
+
+[tool.cytoscnpy]
+
+# ── Core ──────────────────────────────────────────────────────────────────────
+
+# Minimum confidence score (0-100) a finding must reach before it is reported.
+# Lower values surface more findings; higher values reduce noise.
+# confidence = 60
+
+# Scan for hard-coded secrets and high-entropy strings (API keys, tokens, etc.).
+# secrets = true
+
+# Scan for dangerous code patterns: SQL injection, XSS, command injection, etc.
+# danger = true
+
+# Report code-quality issues: high complexity, deep nesting, long functions, etc.
+# quality = true
+
+# Include pytest/unittest test files in the analysis.
+# include_tests = false
+
+# Include Jupyter notebook (.ipynb) cells in the analysis.
+# include_ipynb = false
+
+# How the project is used externally.
+# "library"     – public symbols are assumed to be part of the API (fewer false positives).
+# "application" – reduces public-API assumptions; stricter dead-code detection.
+# project_type = "library"
+
+
+# ── Quality thresholds ────────────────────────────────────────────────────────
+
+# McCabe cyclomatic complexity limit per function. Exceeding this is a finding.
+# max_complexity = 10
+
+# Maximum nesting depth (if/for/while/try) before a finding is emitted.
+# max_nesting = 3
+
+# Maximum number of parameters a function may have.
+# max_args = 5
+
+# Maximum number of lines a function body may span.
+# max_lines = 50
+
+# Minimum Maintainability Index (0-100). Functions below this score are flagged.
+# min_mi = 40.0
+
+
+# ── Path filters ──────────────────────────────────────────────────────────────
+
+# Directories to skip entirely during analysis.
+# exclude_folders = ["build", "dist", ".venv", ".git", "__pycache__", ".mypy_cache", ".pytest_cache"]
+
+# Directories to force-include even when they are git-ignored.
+# include_folders = ["src"]
+
+
+# ── Rule suppression ──────────────────────────────────────────────────────────
+
+# Rule IDs to silence globally across the entire project.
+# ignore = ["CSP-P003"]
+
+# Silence specific rules only for files matching a glob pattern.
+# Use a real table (not an inline `{ ... }`) so it can span multiple lines
+# and hold as many glob -> rule-list entries as you need:
+# [tool.cytoscnpy.per-file-ignores]
+# "tests/*" = ["CSP-D701"]
+# "**/__init__.py" = ["CSP-L001"]
+
+
+# ── Clone detection ───────────────────────────────────────────────────────────
+
+# Detect Type-1/2/3 duplicate code blocks across the project.
+# clones = false
+
+# How similar two blocks must be (0.0-1.0) to be reported as a clone pair.
+# clone_similarity = 0.8
+
+
+# ── CI/CD gate ────────────────────────────────────────────────────────────────
+
+# Exit with code 1 when the percentage of unused definitions exceeds this value.
+# fail_threshold = 5.0
+
+
+# ── Inline whitelist ──────────────────────────────────────────────────────────
+# Suppress specific dead-code symbols without a separate whitelist file.
+# Each entry can target a single name, a wildcard pattern, or a regex.
+# Add as many entries as you need in one array (each entry stays on its own
+# line; only add commas between entries, not inside one):
+# whitelist = [
+#   { name = "my_unused_fn" },
+#   { name = "test_*", pattern = "wildcard" },
+#   { name = "legacy_handler", file = "src/api/*.py" },
+# ]
+
+
+# ── Secrets scanning (advanced) ───────────────────────────────────────────────
+
+# [tool.cytoscnpy.secrets_config]
+# # Shannon entropy threshold; strings above this score are flagged.
+# entropy_threshold = 4.5
+# # Minimum string length before entropy is evaluated.
+# min_length = 16
+# # Enable the entropy-based scanner (disable to use pattern-only mode).
+# entropy_enabled = true
+# # Also scan comments and docstrings for secrets.
+# scan_comments = true
+# # Skip triple-quoted docstrings during secret scanning.
+# skip_docstrings = false
+# # Combined confidence score threshold (0-100) for a secret finding.
+# min_score = 50
+# # Extra variable/parameter names that should be treated as suspicious.
+# suspicious_names = []
+
+# Add custom regex patterns for secret detection:
+# [[tool.cytoscnpy.secrets_config.patterns]]
+# # Human-readable name shown in findings.
+# name = "My Token"
+# # Regular expression to match.
+# regex = "mytoken-[0-9a-zA-Z]{32}"
+# # Severity level: LOW, MEDIUM, HIGH, or CRITICAL.
+# severity = "HIGH"
+
+
+# ── Danger / taint analysis (advanced) ───────────────────────────────────────
+
+# [tool.cytoscnpy.danger_config]
+# # Enable interprocedural taint tracking (data-flow from sources to sinks).
+# enable_taint = true
+# # Minimum severity to report: LOW, MEDIUM, HIGH, or CRITICAL.
+# severity_threshold = "LOW"
+# # Rule IDs to exclude from danger scanning.
+# excluded_rules = []
+# # Fully-qualified function names treated as taint sources.
+# custom_sources = ["mylib.get_input"]
+# # Fully-qualified function names treated as taint sinks.
+# custom_sinks = ["mylib.exec_query"]
+# # Functions that sanitize / clear taint on their return value.
+# [tool.cytoscnpy.danger_config.sanitizers.ssrf]
+# return_value = ["validate_allowed_url"]
+# guard = ["is_allowed_url"]
+# side_effect = ["validate_url_or_raise"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ boolean-py==5.0
 cachecontrol==0.14.4
 certifi==2026.1.4
 charset-normalizer==3.4.4
-click==8.3.1
+click==8.4.2
 colorama==0.4.6
 coverage==7.13.4
 cyclonedx-python-lib==11.6.0

--- a/scripts/pip_audit.py
+++ b/scripts/pip_audit.py
@@ -18,26 +18,27 @@ def load_ignores(ignore_file: Path) -> list[str]:
 
 
 def main() -> int:
-    """Run pip-audit with ignore list loaded from .pip-audit-ignore."""
+    """Audit the managed application and benchmark requirement sets."""
     repo_root = Path(__file__).parent.parent
     ignore_file = repo_root / ".pip-audit-ignore"
+    requirement_sets = (
+        (repo_root / "requirements.txt", repo_root / "requirements-dev.txt"),
+        (repo_root / "benchmark" / "requirements.txt",),
+    )
 
-    cmd = [
-        "uv",
-        "run",
-        "pip-audit",
-        "-r",
-        str(repo_root / "requirements.txt"),
-        "-r",
-        str(repo_root / "requirements-dev.txt"),
-    ]
-    for vuln_id in load_ignores(ignore_file):
-        cmd += ["--ignore-vuln", vuln_id]
-    # Forward any additional arguments passed to this script
-    cmd.extend(sys.argv[1:])
+    for requirements in requirement_sets:
+        cmd = ["uv", "run", "pip-audit"]
+        for requirement_file in requirements:
+            cmd += ["-r", str(requirement_file)]
+        for vuln_id in load_ignores(ignore_file):
+            cmd += ["--ignore-vuln", vuln_id]
+        cmd.extend(sys.argv[1:])
 
-    result = subprocess.run(cmd)
-    return result.returncode
+        result = subprocess.run(cmd)
+        if result.returncode != 0:
+            return result.returncode
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -164,14 +164,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Dependency detection matched declared distributions against imports by name, so anything where those differ was reported both unused and missing. Resolution now prefers evidence, in order: package_mapping config, top_level.txt recorded by the installer in the venv, the built-in table, then the distribution name.

False positives fixed:

- Namespace distributions were reported unused. The namespace check existed but was only wired into the missing path, so google-cloud-storage with rom google.cloud import storage was called unused. Symmetric now, and the root list covers ruamel, sphinxcontrib, backports, jaraco, paste, repoze, zc. google-cloud-storage with rom google.cloud import storage was called unused. Symmetric now, and the root list covers ruamel, sphinxcontrib, backports, jaraco, paste, repoze, zc.
- src layouts reported the project's own package as missing: is_local_package only looked at <root>/pkg, never <root>/src/pkg.
- Analyzing a subdirectory (deps src/) found no manifest and reported every import as missing. The manifest is now located by walking up.
- setup.py / setup.cfg were never parsed, so setuptools projects had no declarations at all. Literal install_requires, extras_require, setup_requires and tests_require are read; a computed requirement list yields nothing rather than a guess. A top-level setup.py is a build script, so its own imports no longer drive findings.
- -r other.txt includes in requirements files were silently dropped.
- Dependencies mapping to several import names (attrs) produced one finding per name instead of one per dependency.

Semantics change: a dependency imported only under if TYPE_CHECKING: is no longer reported as unused. It is still not a runtime import, so it never becomes missing, but deleting it would break type checking, so it counts as usage.

analysis.rs had no tests; it now has 25. No function in the deps module exceeds the CRAP threshold (was 5).