### PR TITLE
fix: reduce false positives in reachability, framework detection, and…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "cytoscnpy"
-version = "1.2.26"
+version = "1.2.27"
 dependencies = [
  "anyhow",
  "askama",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "cytoscnpy-cli"
-version = "1.2.26"
+version = "1.2.27"
 dependencies = [
  "anyhow",
  "cytoscnpy",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "cytoscnpy-mcp"
-version = "1.2.26"
+version = "1.2.27"
 dependencies = [
  "cytoscnpy",
  "rmcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cytoscnpy", "cytoscnpy-cli", "cytoscnpy-mcp"]
 resolver = "2"
 
 [workspace.package]
-version = "1.2.26"
+version = "1.2.27"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/cytoscnpy/src/analyzer/aggregation/mod.rs
+++ b/cytoscnpy/src/analyzer/aggregation/mod.rs
@@ -3,6 +3,7 @@
 mod classify;
 mod reachability;
 mod sorting;
+mod star_imports;
 mod state;
 mod taint;
 
@@ -37,6 +38,7 @@ impl CytoScnPy {
         state.apply_export_reference_increments();
         state.apply_star_import_bindings();
         state.apply_import_binding_reference_increments();
+        state.apply_test_referenced_init_reexports(self.include_tests);
         state.apply_prod_import_binding_reference_increments();
         let total_definitions = state.all_defs.len();
         let functions_count = state

--- a/cytoscnpy/src/analyzer/aggregation/star_imports.rs
+++ b/cytoscnpy/src/analyzer/aggregation/star_imports.rs
@@ -1,0 +1,75 @@
+use super::state::AggregationState;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+impl AggregationState {
+    /// Resolves `from x import *` using explicit `__all__` when present and Python's
+    /// public-name fallback otherwise. Repeated propagation supports star-import chains.
+    pub(super) fn apply_star_import_bindings(&mut self) {
+        let mut public_names = self.collect_public_top_level_names();
+        let explicit_exports: FxHashMap<&str, &[String]> = self
+            .all_module_exports
+            .iter()
+            .map(|(module, names)| (module.as_str(), names.as_slice()))
+            .collect();
+
+        loop {
+            let mut changed = false;
+            for (importer, source) in &self.all_star_imports {
+                let names: Vec<String> = explicit_exports.get(source.as_str()).map_or_else(
+                    || {
+                        public_names
+                            .get(source)
+                            .into_iter()
+                            .flatten()
+                            .cloned()
+                            .collect()
+                    },
+                    |exports| exports.to_vec(),
+                );
+
+                for name in names {
+                    self.all_import_bindings
+                        .entry(format!("{importer}.{name}"))
+                        .or_insert_with(|| format!("{source}.{name}"));
+
+                    if !name.starts_with('_') {
+                        changed |= public_names
+                            .entry(importer.clone())
+                            .or_default()
+                            .insert(name);
+                    }
+                }
+            }
+
+            if !changed {
+                break;
+            }
+        }
+    }
+
+    fn collect_public_top_level_names(&self) -> FxHashMap<String, FxHashSet<String>> {
+        let source_modules: FxHashSet<&str> = self
+            .all_star_imports
+            .iter()
+            .map(|(_, source)| source.as_str())
+            .collect();
+        let mut names: FxHashMap<String, FxHashSet<String>> = FxHashMap::default();
+
+        for source in source_modules {
+            let prefix = format!("{source}.");
+            for definition in &self.all_defs {
+                let Some(local_name) = definition.full_name.strip_prefix(&prefix) else {
+                    continue;
+                };
+                if !local_name.contains('.') && !local_name.starts_with('_') {
+                    names
+                        .entry(source.to_owned())
+                        .or_default()
+                        .insert(local_name.to_owned());
+                }
+            }
+        }
+
+        names
+    }
+}

--- a/cytoscnpy/src/analyzer/aggregation/star_imports.rs
+++ b/cytoscnpy/src/analyzer/aggregation/star_imports.rs
@@ -55,18 +55,15 @@ impl AggregationState {
             .collect();
         let mut names: FxHashMap<String, FxHashSet<String>> = FxHashMap::default();
 
-        for source in source_modules {
-            let prefix = format!("{source}.");
-            for definition in &self.all_defs {
-                let Some(local_name) = definition.full_name.strip_prefix(&prefix) else {
-                    continue;
-                };
-                if !local_name.contains('.') && !local_name.starts_with('_') {
-                    names
-                        .entry(source.to_owned())
-                        .or_default()
-                        .insert(local_name.to_owned());
-                }
+        for definition in &self.all_defs {
+            let Some((module, local_name)) = definition.full_name.rsplit_once('.') else {
+                continue;
+            };
+            if !local_name.starts_with('_') && source_modules.contains(module) {
+                names
+                    .entry(module.to_owned())
+                    .or_default()
+                    .insert(local_name.to_owned());
             }
         }
 

--- a/cytoscnpy/src/analyzer/aggregation/state.rs
+++ b/cytoscnpy/src/analyzer/aggregation/state.rs
@@ -106,6 +106,7 @@ impl AggregationState {
             fixture_imports,
             pytest_plugins,
             exports,
+            exports_declared,
             module_name,
             star_imports,
         } = result;
@@ -170,7 +171,7 @@ impl AggregationState {
         self.all_fixture_imports.extend(fixture_imports);
         self.all_pytest_plugins.extend(pytest_plugins);
 
-        if !exports.is_empty() && !module_name.is_empty() {
+        if exports_declared && !module_name.is_empty() {
             self.all_module_exports.push((module_name.clone(), exports));
         }
         if !module_name.is_empty() {
@@ -215,42 +216,36 @@ impl AggregationState {
         propagate_import_bindings(&mut self.ref_counts, &self.all_import_bindings);
     }
 
+    /// Preserves a source symbol referenced by tests when a package `__init__.py`
+    /// publicly re-exports it. Unused re-export chains are deliberately not seeded.
+    pub(super) fn apply_test_referenced_init_reexports(&mut self, include_tests: bool) {
+        if !include_tests {
+            return;
+        }
+
+        for definition in &self.all_defs {
+            if definition.def_type != crate::visitor::DefinitionType::Import
+                || !definition.in_init
+                || definition.simple_name.starts_with('_')
+            {
+                continue;
+            }
+            let Some(source) = self.all_import_bindings.get(&definition.full_name) else {
+                continue;
+            };
+            if self.ref_counts.get(source).is_some_and(|count| *count > 0) {
+                self.prod_ref_counts
+                    .entry(source.clone())
+                    .and_modify(|count| *count = (*count).max(1))
+                    .or_insert(1);
+            }
+        }
+    }
+
     /// Same as `apply_import_binding_reference_increments` but operates on `prod_ref_counts`.
     /// Must run after `apply_star_import_bindings` and `apply_export_reference_increments`.
     pub(super) fn apply_prod_import_binding_reference_increments(&mut self) {
         propagate_import_bindings(&mut self.prod_ref_counts, &self.all_import_bindings);
-    }
-
-    /// Resolves `from x import *` cross-file.
-    ///
-    /// For each recorded star-import `(importer_module, source_module)`, looks up the
-    /// source module's `__all__` exports (collected during file analysis)
-    /// and synthesises explicit import bindings:
-    ///   `importer_module.Name  →  source_module.Name`
-    ///
-    /// This must run **before** `apply_import_binding_reference_increments` so the new bindings feed
-    /// into the worklist.
-    ///
-    pub(super) fn apply_star_import_bindings(&mut self) {
-        // Build a fast lookup: source_module → [exported_names]
-        let mut export_map: FxHashMap<&str, &[String]> = FxHashMap::default();
-        for (module, names) in &self.all_module_exports {
-            export_map.insert(module.as_str(), names.as_slice());
-        }
-
-        for (importer, source) in &self.all_star_imports {
-            let Some(names) = export_map.get(source.as_str()) else {
-                continue;
-            };
-            for name in *names {
-                let local_key = format!("{importer}.{name}");
-                let source_val = format!("{source}.{name}");
-                // Synthesise binding: importer.Name → source.Name
-                self.all_import_bindings
-                    .entry(local_key)
-                    .or_insert(source_val);
-            }
-        }
     }
 
     /// For every symbol listed in any module's `__all__`, ensures its qualified name

--- a/cytoscnpy/src/analyzer/aggregation/state.rs
+++ b/cytoscnpy/src/analyzer/aggregation/state.rs
@@ -238,6 +238,10 @@ impl AggregationState {
                     .entry(source.clone())
                     .and_modify(|count| *count = (*count).max(1))
                     .or_insert(1);
+                self.prod_ref_counts
+                    .entry(definition.full_name.clone())
+                    .and_modify(|count| *count = (*count).max(1))
+                    .or_insert(1);
             }
         }
     }

--- a/cytoscnpy/src/analyzer/single_file/common.rs
+++ b/cytoscnpy/src/analyzer/single_file/common.rs
@@ -3,7 +3,10 @@ use crate::rules::Finding;
 use std::path::Path;
 
 pub(super) fn module_name_from_path(file_path: &Path, root_path: &Path) -> String {
-    let relative_path = file_path.strip_prefix(root_path).unwrap_or(file_path);
+    let package_relative = package_relative_path(file_path);
+    let relative_path = package_relative
+        .as_deref()
+        .unwrap_or_else(|| file_path.strip_prefix(root_path).unwrap_or(file_path));
     let components: Vec<&str> = relative_path
         .components()
         .filter_map(|component| component.as_os_str().to_str())
@@ -24,6 +27,25 @@ pub(super) fn module_name_from_path(file_path: &Path, root_path: &Path) -> Strin
     }
 
     module_parts.join(".")
+}
+
+/// Returns the path from the import root when the file belongs to a regular package.
+/// This intentionally walks above the analysis root so scanning a package subdirectory
+/// still produces the same qualified names as Python imports.
+fn package_relative_path(file_path: &Path) -> Option<std::path::PathBuf> {
+    let mut current = file_path.parent()?;
+    let mut top_package = None;
+
+    while current.join("__init__.py").is_file() {
+        top_package = Some(current);
+        current = current.parent()?;
+    }
+
+    let top_package = top_package?;
+    file_path
+        .strip_prefix(top_package.parent()?)
+        .ok()
+        .map(Path::to_path_buf)
 }
 
 pub(super) fn split_lint_finding(

--- a/cytoscnpy/src/analyzer/single_file/process.rs
+++ b/cytoscnpy/src/analyzer/single_file/process.rs
@@ -72,6 +72,7 @@ impl CytoScnPy {
             fixture_imports: output.fixture_metadata.fixture_imports,
             pytest_plugins: output.fixture_metadata.pytest_plugins,
             exports: output.visitor.exports,
+            exports_declared: output.visitor.exports_declared,
             module_name: module_name.clone(),
             star_imports: output.visitor.star_imports,
         }

--- a/cytoscnpy/src/analyzer/types.rs
+++ b/cytoscnpy/src/analyzer/types.rs
@@ -119,6 +119,8 @@ pub struct FileAnalysisResult {
     pub(crate) pytest_plugins: Vec<PytestPluginDeclaration>,
     /// Names explicitly listed in this file's `__all__` (unqualified).
     pub(crate) exports: Vec<String>,
+    /// Whether this file declares `__all__`, even if the declared list is empty.
+    pub(crate) exports_declared: bool,
     /// Dotted module name for this file (e.g. `"pkg.sub.module"`).
     pub(crate) module_name: String,
     /// Resolved source module names for each `from x import *` in this file.
@@ -151,6 +153,7 @@ impl FileAnalysisResult {
             fixture_imports: Vec::new(),
             pytest_plugins: Vec::new(),
             exports: Vec::new(),
+            exports_declared: false,
             module_name: String::new(),
             star_imports: Vec::new(),
         }

--- a/cytoscnpy/src/clones/detector/cache.rs
+++ b/cytoscnpy/src/clones/detector/cache.rs
@@ -13,7 +13,7 @@ pub(super) struct PreparedSubtree {
     pub(super) id_tree: NormalizedTree,
 }
 
-/// Bounded FIFO cache for parsed and normalized candidate files.
+/// Bounded LRU cache for parsed and normalized candidate files.
 #[derive(Default)]
 pub(super) struct PairSubtreeCache {
     entries: HashMap<PathBuf, Vec<PreparedSubtree>>,
@@ -23,6 +23,10 @@ pub(super) struct PairSubtreeCache {
 impl PairSubtreeCache {
     pub(super) fn load(&mut self, file: &PathBuf, min_lines: usize) {
         if self.entries.contains_key(file) {
+            if let Some(position) = self.insertion_order.iter().position(|path| path == file) {
+                let _ = self.insertion_order.remove(position);
+                self.insertion_order.push_back(file.clone());
+            }
             return;
         }
         if self.entries.len() == MAX_PAIR_CACHE_FILES {
@@ -46,6 +50,11 @@ impl PairSubtreeCache {
     #[cfg(test)]
     pub(super) fn len(&self) -> usize {
         self.entries.len()
+    }
+
+    #[cfg(test)]
+    fn contains(&self, file: &PathBuf) -> bool {
+        self.entries.contains_key(file)
     }
 }
 
@@ -93,5 +102,23 @@ mod tests {
         }
         assert_eq!(cache.len(), MAX_PAIR_CACHE_FILES);
         assert!(cache.find(&PathBuf::from("missing-0.py"), 0).is_none());
+    }
+
+    #[test]
+    fn cache_hit_keeps_active_file_resident() {
+        let mut cache = PairSubtreeCache::default();
+        for index in 0..MAX_PAIR_CACHE_FILES {
+            cache.load(&PathBuf::from(format!("missing-{index}.py")), 1);
+        }
+
+        let active = PathBuf::from("missing-0.py");
+        cache.load(&active, 1);
+        cache.load(
+            &PathBuf::from(format!("missing-{MAX_PAIR_CACHE_FILES}.py")),
+            1,
+        );
+
+        assert!(cache.contains(&active));
+        assert!(!cache.contains(&PathBuf::from("missing-1.py")));
     }
 }

--- a/cytoscnpy/src/clones/detector/cfg_validation.rs
+++ b/cytoscnpy/src/clones/detector/cfg_validation.rs
@@ -39,6 +39,7 @@ impl CloneDetector {
     pub(super) fn validate_with_cfg_from_paths(
         &self,
         pairs: Vec<ClonePair>,
+        cache: &mut super::cache::PairSubtreeCache,
         min_lines: usize,
     ) -> Vec<ClonePair> {
         let threshold = self.config.cfg_similarity_threshold;
@@ -46,14 +47,18 @@ impl CloneDetector {
         pairs
             .into_iter()
             .filter(|pair| {
-                let Some(subtree_a) = load_subtree(&pair.instance_a, min_lines) else {
+                cache.load(&pair.instance_a.file, min_lines);
+                cache.load(&pair.instance_b.file, min_lines);
+                let Some(subtree_a) = cache.find(&pair.instance_a.file, pair.instance_a.start_byte)
+                else {
                     return false;
                 };
-                let Some(subtree_b) = load_subtree(&pair.instance_b, min_lines) else {
+                let Some(subtree_b) = cache.find(&pair.instance_b.file, pair.instance_b.start_byte)
+                else {
                     return false;
                 };
 
-                cfg_subtrees_match(&subtree_a, &subtree_b, threshold)
+                cfg_subtrees_match(&subtree_a.subtree, &subtree_b.subtree, threshold)
             })
             .collect()
     }
@@ -103,21 +108,10 @@ fn cfg_subtrees_match(
     matches!((cfg_a, cfg_b), (Some(a), Some(b)) if a.similarity_score(&b) >= threshold)
 }
 
-#[cfg(feature = "cfg")]
-fn load_subtree(
-    instance: &crate::clones::CloneInstance,
-    min_lines: usize,
-) -> Option<parser::Subtree> {
-    let source = std::fs::read_to_string(&instance.file).ok()?;
-    parser::extract_subtrees_with_min_lines(&source, &instance.file, min_lines)
-        .ok()?
-        .into_iter()
-        .find(|subtree| subtree.start_byte == instance.start_byte)
-}
-
 #[cfg(all(test, feature = "cfg"))]
 mod tests {
     use super::{dedent_definition, CloneDetector};
+    use crate::clones::detector::cache::PairSubtreeCache;
     use crate::clones::{CloneConfig, CloneInstance, ClonePair, CloneType, NodeKind};
     use std::path::PathBuf;
 
@@ -151,8 +145,9 @@ mod tests {
         };
         let detector = CloneDetector::with_config(CloneConfig::default().with_cfg_validation(true))
             .expect("valid clone config");
+        let mut cache = PairSubtreeCache::default();
         assert!(detector
-            .validate_with_cfg_from_paths(vec![pair], 1)
+            .validate_with_cfg_from_paths(vec![pair], &mut cache, 1)
             .is_empty());
     }
 }

--- a/cytoscnpy/src/clones/detector/paths.rs
+++ b/cytoscnpy/src/clones/detector/paths.rs
@@ -163,7 +163,11 @@ fn find_and_group_clones(
 
     #[cfg(feature = "cfg")]
     if detector.config.cfg_validation {
-        pairs = detector.validate_with_cfg_from_paths(pairs, detector.config.min_lines);
+        pairs = detector.validate_with_cfg_from_paths(
+            pairs,
+            &mut subtree_cache,
+            detector.config.min_lines,
+        );
     }
 
     let groups = CloneDetector::group_clones(&pairs);

--- a/cytoscnpy/src/complexity/analysis.rs
+++ b/cytoscnpy/src/complexity/analysis.rs
@@ -2,7 +2,7 @@ use crate::metrics::cc_rank;
 use crate::utils::LineIndex;
 use ruff_text_size::Ranged;
 
-use super::block::calculate_complexity;
+use super::block::{calculate_complexity, calculate_total_complexity};
 use super::visitor::ComplexityVisitor;
 
 /// A finding related to Cyclomatic Complexity.
@@ -59,7 +59,7 @@ pub fn analyze_complexity(
 pub fn calculate_module_complexity(code: &str) -> Option<usize> {
     if let Ok(parsed) = ruff_python_parser::parse_module(code) {
         let module = parsed.into_syntax();
-        return Some(calculate_complexity(&module.body, false));
+        return Some(calculate_total_complexity(&module.body, false));
     }
     None
 }
@@ -70,5 +70,5 @@ pub fn calculate_module_complexity(code: &str) -> Option<usize> {
 /// source — for callers that already hold the parsed AST.
 #[must_use]
 pub fn calculate_module_complexity_ast(module: &ruff_python_ast::ModModule) -> usize {
-    calculate_complexity(&module.body, false)
+    calculate_total_complexity(&module.body, false)
 }

--- a/cytoscnpy/src/complexity/block.rs
+++ b/cytoscnpy/src/complexity/block.rs
@@ -4,9 +4,22 @@ mod expression_traversal;
 mod statement_traversal;
 
 pub(super) fn calculate_complexity(body: &[Stmt], no_assert: bool) -> usize {
+    calculate_complexity_with_nested(body, no_assert, false)
+}
+
+pub(super) fn calculate_total_complexity(body: &[Stmt], no_assert: bool) -> usize {
+    calculate_complexity_with_nested(body, no_assert, true)
+}
+
+fn calculate_complexity_with_nested(
+    body: &[Stmt],
+    no_assert: bool,
+    descend_definitions: bool,
+) -> usize {
     let mut visitor = BlockComplexityVisitor {
         complexity: 1,
         no_assert,
+        descend_definitions,
     };
     visitor.visit_body(body);
     visitor.complexity
@@ -15,6 +28,7 @@ pub(super) fn calculate_complexity(body: &[Stmt], no_assert: bool) -> usize {
 struct BlockComplexityVisitor {
     complexity: usize,
     no_assert: bool,
+    descend_definitions: bool,
 }
 
 fn is_wildcard_case(pattern: &ast::Pattern) -> bool {

--- a/cytoscnpy/src/complexity/block/statement_traversal.rs
+++ b/cytoscnpy/src/complexity/block/statement_traversal.rs
@@ -114,8 +114,9 @@ impl BlockComplexityVisitor {
 
     fn visit_definition_stmt(&mut self, stmt: &Stmt) -> bool {
         match stmt {
-            Stmt::FunctionDef(node) => self.visit_body(&node.body),
-            Stmt::ClassDef(node) => self.visit_body(&node.body),
+            Stmt::FunctionDef(node) if self.descend_definitions => self.visit_body(&node.body),
+            Stmt::ClassDef(node) if self.descend_definitions => self.visit_body(&node.body),
+            Stmt::FunctionDef(_) | Stmt::ClassDef(_) => {}
             _ => return false,
         }
         true

--- a/cytoscnpy/src/framework/constants.rs
+++ b/cytoscnpy/src/framework/constants.rs
@@ -68,3 +68,17 @@ pub static FRAMEWORK_FUNCTIONS: &[&str] = &[
     "form_invalid",
     "*_queryset",
 ];
+
+/// Exact framework base-class names whose methods are invoked by framework dispatch.
+pub(super) static FRAMEWORK_BASE_CLASSES: &[&str] = &[
+    "view",
+    "apiview",
+    "genericapiview",
+    "viewset",
+    "genericviewset",
+    "modelviewset",
+    "readonlymodelviewset",
+    "schema",
+    "basemodel",
+    "model",
+];

--- a/cytoscnpy/src/framework/decorators.rs
+++ b/cytoscnpy/src/framework/decorators.rs
@@ -35,20 +35,25 @@ fn get_decorator_name(decorator: &Expr) -> String {
     }
 }
 
+const BLUEPRINT_METHODS: &[&str] = &[
+    "route", "get", "post", "put", "delete", "patch", "head", "options",
+];
+
 fn is_relative_blueprint_route(visitor: &FrameworkAwareVisitor, name: &str) -> bool {
     let Some((owner, method)) = name.rsplit_once('.') else {
         return false;
     };
-    method == "route" && visitor.relative_imported_symbols.contains(owner)
+    BLUEPRINT_METHODS.contains(&method) && visitor.relative_imported_symbols.contains(owner)
 }
 
 fn is_framework_decorator(name: &str) -> bool {
     let method = name.rsplit('.').next().unwrap_or(name);
     FRAMEWORK_DECORATORS.iter().any(|pattern| {
         let pattern = pattern.trim_start_matches('@');
-        pattern
-            .strip_prefix("*.")
-            .is_some_and(|expected| method == expected)
-            || pattern == name
+        if let Some(expected) = pattern.strip_prefix("*.") {
+            method == expected
+        } else {
+            pattern == name || pattern == method
+        }
     })
 }

--- a/cytoscnpy/src/framework/decorators.rs
+++ b/cytoscnpy/src/framework/decorators.rs
@@ -11,6 +11,10 @@ pub(super) fn check_decorators(
         let name = get_decorator_name(&decorator.expression);
         if visitor.is_framework_file && is_framework_decorator(&name) {
             visitor.framework_decorated_lines.insert(line);
+        } else if is_relative_blueprint_route(visitor, &name) {
+            visitor.is_framework_file = true;
+            visitor.detected_frameworks.insert("flask".to_owned());
+            visitor.framework_decorated_lines.insert(line);
         }
     }
 }
@@ -18,10 +22,24 @@ pub(super) fn check_decorators(
 fn get_decorator_name(decorator: &Expr) -> String {
     match decorator {
         Expr::Name(node) => node.id.to_string(),
-        Expr::Attribute(node) => node.attr.to_string(),
+        Expr::Attribute(node) => {
+            let owner = get_decorator_name(&node.value);
+            if owner.is_empty() {
+                node.attr.to_string()
+            } else {
+                format!("{owner}.{}", node.attr)
+            }
+        }
         Expr::Call(node) => get_decorator_name(&node.func),
         _ => String::new(),
     }
+}
+
+fn is_relative_blueprint_route(visitor: &FrameworkAwareVisitor, name: &str) -> bool {
+    let Some((owner, method)) = name.rsplit_once('.') else {
+        return false;
+    };
+    method == "route" && visitor.relative_imported_symbols.contains(owner)
 }
 
 fn is_framework_decorator(name: &str) -> bool {

--- a/cytoscnpy/src/framework/django.rs
+++ b/cytoscnpy/src/framework/django.rs
@@ -50,7 +50,19 @@ pub(super) fn check_django_call_patterns(visitor: &mut FrameworkAwareVisitor, ex
         if function_name == "add_url_rule" {
             visitor.is_framework_file = true;
             visitor.detected_frameworks.insert("flask".to_owned());
-            if let Some(view) = call.arguments.args.get(2) {
+            let view = call
+                .arguments
+                .keywords
+                .iter()
+                .find(|keyword| {
+                    keyword
+                        .arg
+                        .as_ref()
+                        .is_some_and(|name| name.as_str() == "view_func")
+                })
+                .map(|keyword| &keyword.value)
+                .or_else(|| call.arguments.args.get(2));
+            if let Some(view) = view {
                 extract_view_reference(visitor, view);
             }
         }

--- a/cytoscnpy/src/framework/visitor.rs
+++ b/cytoscnpy/src/framework/visitor.rs
@@ -39,8 +39,12 @@ impl<'a> FrameworkAwareVisitor<'a> {
         }
     }
 
-    /// Visits a statement and updates framework detection state.
+    /// Visits a top-level module statement and updates framework detection state.
     pub fn visit_stmt(&mut self, stmt: &Stmt) {
+        self.visit_stmt_inner(stmt, true);
+    }
+
+    fn visit_stmt_inner(&mut self, stmt: &Stmt, is_module_scope: bool) {
         match stmt {
             Stmt::Import(node) => {
                 for alias in &node.names {
@@ -54,7 +58,7 @@ impl<'a> FrameworkAwareVisitor<'a> {
                 }
             }
             Stmt::ImportFrom(node) => {
-                if node.level > 0 {
+                if is_module_scope && node.level > 0 {
                     for alias in &node.names {
                         let local_name = alias.asname.as_ref().unwrap_or(&alias.name);
                         if local_name.as_str() != "*" {
@@ -79,7 +83,7 @@ impl<'a> FrameworkAwareVisitor<'a> {
                 check_decorators(self, &node.decorator_list, line);
                 extract_fastapi_depends(self, &node.parameters);
                 for nested in &node.body {
-                    self.visit_stmt(nested);
+                    self.visit_stmt_inner(nested, false);
                 }
             }
             Stmt::ClassDef(node) => {
@@ -123,7 +127,7 @@ impl<'a> FrameworkAwareVisitor<'a> {
                             }
                         }
                     }
-                    self.visit_stmt(nested);
+                    self.visit_stmt_inner(nested, false);
                 }
             }
             Stmt::Assign(node) => {

--- a/cytoscnpy/src/framework/visitor.rs
+++ b/cytoscnpy/src/framework/visitor.rs
@@ -3,6 +3,7 @@ use ruff_python_ast::{Expr, Stmt};
 use ruff_text_size::Ranged;
 use rustc_hash::FxHashSet;
 
+use super::constants::FRAMEWORK_BASE_CLASSES;
 use super::decorators::check_decorators;
 use super::django::{check_django_call_patterns, extract_urlpatterns_views};
 use super::fastapi::extract_fastapi_depends;
@@ -20,6 +21,8 @@ pub struct FrameworkAwareVisitor<'a> {
     pub line_index: &'a LineIndex,
     /// Symbol names referenced implicitly by framework conventions.
     pub framework_references: Vec<String>,
+    /// Symbols imported from sibling package modules, used for blueprint provenance.
+    pub(super) relative_imported_symbols: FxHashSet<String>,
 }
 
 impl<'a> FrameworkAwareVisitor<'a> {
@@ -32,6 +35,7 @@ impl<'a> FrameworkAwareVisitor<'a> {
             framework_decorated_lines: FxHashSet::default(),
             line_index,
             framework_references: Vec::new(),
+            relative_imported_symbols: FxHashSet::default(),
         }
     }
 
@@ -50,6 +54,15 @@ impl<'a> FrameworkAwareVisitor<'a> {
                 }
             }
             Stmt::ImportFrom(node) => {
+                if node.level > 0 {
+                    for alias in &node.names {
+                        let local_name = alias.asname.as_ref().unwrap_or(&alias.name);
+                        if local_name.as_str() != "*" {
+                            self.relative_imported_symbols
+                                .insert(local_name.to_string());
+                        }
+                    }
+                }
                 if let Some(module) = &node.module {
                     let module_name = module.as_str();
                     if let Some(framework) = get_framework_imports().iter().find(|framework| {
@@ -82,10 +95,7 @@ impl<'a> FrameworkAwareVisitor<'a> {
                     if let Some(id) = &id {
                         let id_lower = id.to_lowercase();
                         if self.is_framework_file
-                            && matches!(
-                                id_lower.as_str(),
-                                "view" | "apiview" | "schema" | "basemodel" | "model"
-                            )
+                            && FRAMEWORK_BASE_CLASSES.contains(&id_lower.as_str())
                         {
                             is_framework_class = true;
                             let line = self.line_index.line_index(node.name.range().start());

--- a/cytoscnpy/src/raw_metrics.rs
+++ b/cytoscnpy/src/raw_metrics.rs
@@ -1,10 +1,10 @@
 use crate::utils::LineIndex;
-use ruff_python_ast::visitor::{self, Visitor};
-use ruff_python_ast::{Expr, ModModule, Stmt};
+use ruff_python_ast::ModModule;
 use ruff_python_parser::parse_module;
-use ruff_text_size::Ranged;
-
 use serde::{Deserialize, Serialize};
+
+mod collectors;
+use collectors::{collect_docstring_ranges, collect_string_ranges, count_logical_lines};
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 /// Raw metrics gathered from source code analysis.
@@ -25,109 +25,6 @@ pub struct RawMetrics {
     pub single_comments: usize,
 }
 
-struct StringCollector {
-    ranges: Vec<(usize, usize)>,
-}
-
-#[derive(Default)]
-struct DocstringCollector {
-    ranges: Vec<(usize, usize)>,
-}
-
-impl<'a> Visitor<'a> for DocstringCollector {
-    fn visit_stmt(&mut self, stmt: &'a Stmt) {
-        match stmt {
-            Stmt::FunctionDef(node) => collect_body_docstring(&node.body, &mut self.ranges),
-            Stmt::ClassDef(node) => collect_body_docstring(&node.body, &mut self.ranges),
-            _ => {}
-        }
-        visitor::walk_stmt(self, stmt);
-    }
-}
-
-#[derive(Default)]
-struct LogicalLineCounter {
-    count: usize,
-}
-
-impl<'a> Visitor<'a> for LogicalLineCounter {
-    fn visit_stmt(&mut self, stmt: &'a Stmt) {
-        if matches!(stmt, Stmt::Expr(node) if matches!(node.value.as_ref(), Expr::StringLiteral(_)))
-        {
-            return;
-        }
-        self.count += 1;
-        visitor::walk_stmt(self, stmt);
-    }
-}
-
-impl<'a> Visitor<'a> for StringCollector {
-    fn visit_expr(&mut self, expr: &'a Expr) {
-        self.collect_string_range(expr);
-        visitor::walk_expr(self, expr);
-    }
-}
-
-impl StringCollector {
-    fn collect_string_range(&mut self, expr: &Expr) {
-        match expr {
-            Expr::StringLiteral(s) => {
-                let range = s.range();
-                self.ranges
-                    .push((range.start().to_usize(), range.end().to_usize()));
-            }
-            Expr::BytesLiteral(b) => {
-                let range = b.range();
-                self.ranges
-                    .push((range.start().to_usize(), range.end().to_usize()));
-            }
-            Expr::FString(f) => {
-                let range = f.range();
-                self.ranges
-                    .push((range.start().to_usize(), range.end().to_usize()));
-            }
-            _ => {}
-        }
-    }
-}
-
-/// Collects byte ranges of all string/bytes/f-string literals in a module body.
-fn collect_string_ranges(body: &[Stmt]) -> Vec<(usize, usize)> {
-    let mut collector = StringCollector { ranges: Vec::new() };
-    for stmt in body {
-        collector.visit_stmt(stmt);
-    }
-    collector.ranges
-}
-
-fn collect_docstring_ranges(body: &[Stmt]) -> Vec<(usize, usize)> {
-    let mut collector = DocstringCollector::default();
-    collect_body_docstring(body, &mut collector.ranges);
-    for stmt in body {
-        collector.visit_stmt(stmt);
-    }
-    collector.ranges
-}
-
-fn collect_body_docstring(body: &[Stmt], ranges: &mut Vec<(usize, usize)>) {
-    let Some(Stmt::Expr(node)) = body.first() else {
-        return;
-    };
-    let Expr::StringLiteral(string) = node.value.as_ref() else {
-        return;
-    };
-    let range = string.range();
-    ranges.push((range.start().to_usize(), range.end().to_usize()));
-}
-
-fn count_logical_lines(body: &[Stmt]) -> usize {
-    let mut counter = LogicalLineCounter::default();
-    for stmt in body {
-        counter.visit_stmt(stmt);
-    }
-    counter.count
-}
-
 /// Analyzes raw metrics (LOC, SLOC, etc.) from source code.
 ///
 /// Parses `code` internally. Callers that already hold the parsed AST should
@@ -140,10 +37,10 @@ pub fn analyze_raw(code: &str) -> RawMetrics {
             (
                 collect_string_ranges(&module.body),
                 collect_docstring_ranges(&module.body),
-                count_logical_lines(&module.body),
+                Some(count_logical_lines(&module.body)),
             )
         }
-        Err(_) => (Vec::new(), Vec::new(), 0),
+        Err(_) => (Vec::new(), Vec::new(), None),
     };
     analyze_raw_inner(code, &string_ranges, &docstring_ranges, lloc)
 }
@@ -159,7 +56,7 @@ pub fn analyze_raw_with_module(code: &str, module: &ModModule) -> RawMetrics {
         code,
         &string_ranges,
         &docstring_ranges,
-        count_logical_lines(&module.body),
+        Some(count_logical_lines(&module.body)),
     )
 }
 
@@ -167,7 +64,7 @@ fn analyze_raw_inner(
     code: &str,
     string_ranges: &[(usize, usize)],
     docstring_ranges: &[(usize, usize)],
-    lloc: usize,
+    lloc: Option<usize>,
 ) -> RawMetrics {
     let mut metrics = RawMetrics::default();
 
@@ -256,7 +153,27 @@ fn analyze_raw_inner(
     }
 
     // 4. Aggregate metrics
-    metrics.multi = 0;
+    let mut assigned_multiline_lines = vec![false; metrics.loc + 1];
+    for (start_offset, end_offset) in string_ranges {
+        let start_row = line_index.line_index(ruff_text_size::TextSize::new(
+            u32::try_from(*start_offset).unwrap_or(0),
+        ));
+        let end_row = line_index.line_index(ruff_text_size::TextSize::new(
+            u32::try_from(*end_offset).unwrap_or(0),
+        ));
+        if end_row > start_row {
+            for row in start_row..=std::cmp::min(end_row, metrics.loc) {
+                if line_types[row] == LineType::Code {
+                    assigned_multiline_lines[row] = true;
+                }
+            }
+        }
+    }
+
+    metrics.multi = assigned_multiline_lines
+        .into_iter()
+        .filter(|is_multiline| *is_multiline)
+        .count();
     metrics.comments = inline_comments;
     metrics.sloc = 0;
 
@@ -274,7 +191,7 @@ fn analyze_raw_inner(
         }
     }
 
-    metrics.lloc = lloc;
+    metrics.lloc = lloc.unwrap_or(metrics.sloc);
 
     metrics
 }

--- a/cytoscnpy/src/raw_metrics/collectors.rs
+++ b/cytoscnpy/src/raw_metrics/collectors.rs
@@ -1,0 +1,98 @@
+use ruff_python_ast::visitor::{self, Visitor};
+use ruff_python_ast::{Expr, Stmt};
+use ruff_text_size::Ranged;
+
+struct StringCollector {
+    ranges: Vec<(usize, usize)>,
+}
+
+#[derive(Default)]
+struct DocstringCollector {
+    ranges: Vec<(usize, usize)>,
+}
+
+impl<'a> Visitor<'a> for DocstringCollector {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        match stmt {
+            Stmt::FunctionDef(node) => collect_body_docstring(&node.body, &mut self.ranges),
+            Stmt::ClassDef(node) => collect_body_docstring(&node.body, &mut self.ranges),
+            _ => {}
+        }
+        visitor::walk_stmt(self, stmt);
+    }
+}
+
+#[derive(Default)]
+struct LogicalLineCounter {
+    count: usize,
+}
+
+impl<'a> Visitor<'a> for LogicalLineCounter {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        if matches!(stmt, Stmt::Expr(node) if matches!(node.value.as_ref(), Expr::StringLiteral(_)))
+        {
+            return;
+        }
+        self.count += 1;
+        visitor::walk_stmt(self, stmt);
+    }
+}
+
+impl<'a> Visitor<'a> for StringCollector {
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        self.collect_string_range(expr);
+        visitor::walk_expr(self, expr);
+    }
+}
+
+impl StringCollector {
+    fn collect_string_range(&mut self, expr: &Expr) {
+        match expr {
+            Expr::StringLiteral(string) => self.push_range(string.range()),
+            Expr::BytesLiteral(bytes) => self.push_range(bytes.range()),
+            Expr::FString(fstring) => self.push_range(fstring.range()),
+            _ => {}
+        }
+    }
+
+    fn push_range(&mut self, range: ruff_text_size::TextRange) {
+        self.ranges
+            .push((range.start().to_usize(), range.end().to_usize()));
+    }
+}
+
+pub(super) fn collect_string_ranges(body: &[Stmt]) -> Vec<(usize, usize)> {
+    let mut collector = StringCollector { ranges: Vec::new() };
+    for stmt in body {
+        collector.visit_stmt(stmt);
+    }
+    collector.ranges
+}
+
+pub(super) fn collect_docstring_ranges(body: &[Stmt]) -> Vec<(usize, usize)> {
+    let mut collector = DocstringCollector::default();
+    collect_body_docstring(body, &mut collector.ranges);
+    for stmt in body {
+        collector.visit_stmt(stmt);
+    }
+    collector.ranges
+}
+
+fn collect_body_docstring(body: &[Stmt], ranges: &mut Vec<(usize, usize)>) {
+    let Some(Stmt::Expr(node)) = body.first() else {
+        return;
+    };
+    let Expr::StringLiteral(string) = node.value.as_ref() else {
+        return;
+    };
+    let range = string.range();
+    ranges.push((range.start().to_usize(), range.end().to_usize()));
+}
+
+pub(super) fn count_logical_lines(body: &[Stmt]) -> usize {
+    let mut counter = LogicalLineCounter::default();
+    for stmt in body {
+        counter.visit_stmt(stmt);
+    }
+    counter.count
+}

--- a/cytoscnpy/src/report/gitlab.rs
+++ b/cytoscnpy/src/report/gitlab.rs
@@ -128,9 +128,20 @@ fn add_secrets_issues(
 ) {
     for secret in &result.secrets {
         let normalized_path = normalize_path(&secret.file, root);
+        let matched = secret.matched_value.as_deref().unwrap_or("-");
+        let entropy = secret
+            .entropy
+            .map(|value| format!("{value:.4}"))
+            .unwrap_or_else(|| "-".to_owned());
         let fingerprint = format!(
-            "secret-{}-{}-{}",
-            secret.rule_id, normalized_path, secret.line
+            "secret-{}-{}-{}-{}-{}-{}-{}",
+            secret.rule_id,
+            normalized_path,
+            secret.line,
+            secret.confidence,
+            secret.message,
+            matched,
+            entropy
         );
         issues.push(make_gitlab_issue(
             &secret.message,

--- a/cytoscnpy/src/visitor/constructor.rs
+++ b/cytoscnpy/src/visitor/constructor.rs
@@ -26,6 +26,7 @@ impl<'a> CytoScnPyVisitor<'a> {
             definitions: Vec::new(),
             references: FxHashMap::default(),
             exports: Vec::new(),
+            exports_declared: false,
             dynamic_imports: Vec::new(),
             project_type,
             file_path,

--- a/cytoscnpy/src/visitor/state.rs
+++ b/cytoscnpy/src/visitor/state.rs
@@ -8,6 +8,8 @@ pub struct CytoScnPyVisitor<'a> {
     pub references: FxHashMap<String, usize>,
     /// Names explicitly exported via `__all__`.
     pub exports: Vec<String>,
+    /// Whether this module declares `__all__`, including an explicitly empty list.
+    pub exports_declared: bool,
     /// Dynamic imports detected.
     pub dynamic_imports: Vec<String>,
     /// Project type controls public API export assumptions.

--- a/cytoscnpy/src/visitor/stmt_assignments.rs
+++ b/cytoscnpy/src/visitor/stmt_assignments.rs
@@ -3,6 +3,7 @@ use super::{ast, CytoScnPyVisitor, DefinitionInfo, DefinitionType, Expr, SmallVe
 impl CytoScnPyVisitor<'_> {
     pub(super) fn handle_assign_stmt(&mut self, node: &ast::StmtAssign) {
         if node.targets.iter().any(Self::is_all_name_expr) {
+            self.exports_declared = true;
             if Self::is_all_present_in_expr(&node.value) {
                 self.extend_exports_from_expr(&node.value);
             } else {
@@ -87,6 +88,7 @@ impl CytoScnPyVisitor<'_> {
 
     pub(super) fn handle_aug_assign_stmt(&mut self, node: &ast::StmtAugAssign) {
         if Self::is_all_name_expr(&node.target) {
+            self.exports_declared = true;
             self.extend_exports_from_expr(&node.value);
         }
         self.visit_expr(&node.target);

--- a/cytoscnpy/src/visitor/stmt_assignments.rs
+++ b/cytoscnpy/src/visitor/stmt_assignments.rs
@@ -1,8 +1,12 @@
-use super::{ast, CytoScnPyVisitor, DefinitionInfo, DefinitionType, Expr, SmallVec};
+use super::{ast, CytoScnPyVisitor, DefinitionInfo, DefinitionType, Expr, ScopeType, SmallVec};
 
 impl CytoScnPyVisitor<'_> {
     pub(super) fn handle_assign_stmt(&mut self, node: &ast::StmtAssign) {
-        if node.targets.iter().any(Self::is_all_name_expr) {
+        let is_module_scope = self
+            .scope_stack
+            .last()
+            .is_some_and(|scope| scope.kind == ScopeType::Module);
+        if is_module_scope && node.targets.iter().any(Self::is_all_name_expr) {
             self.exports_declared = true;
             if Self::is_all_present_in_expr(&node.value) {
                 self.extend_exports_from_expr(&node.value);

--- a/cytoscnpy/src/visitor/stmt_imports.rs
+++ b/cytoscnpy/src/visitor/stmt_imports.rs
@@ -81,8 +81,6 @@ impl CytoScnPyVisitor<'_> {
                 self.alias_map.insert(asname.to_string(), full_name.clone());
                 self.import_bindings
                     .insert(self.get_qualified_name(asname.as_str()), full_name.clone());
-                // Importing a symbol is itself a static dependency on that source symbol.
-                self.add_ref(&full_name);
             } else {
                 self.alias_map
                     .insert(asname.to_string(), alias.name.to_string());

--- a/cytoscnpy/tests/cli_metrics_test.rs
+++ b/cytoscnpy/tests/cli_metrics_test.rs
@@ -49,7 +49,7 @@ fn test_cli_raw() {
     let output = String::from_utf8(buffer).unwrap();
     assert!(output.contains("test.py"));
     assert!(output.contains("LOC"));
-    assert!(output.contains('3')); // LOC (x=1, #comment, newline)
+    assert!(output.contains('2')); // LOC (x=1, #comment); trailing newline is not a line
     assert!(output.contains('1')); // SLOC/Comments
 }
 
@@ -157,10 +157,9 @@ fn test_cli_json_output() {
     )
     .unwrap();
 
-    let output = String::from_utf8(buffer).unwrap();
-    assert!(output.contains("\"file\":"));
-    assert!(output.contains("\"loc\":"));
-    assert!(output.contains('2'));
+    let output: serde_json::Value = serde_json::from_slice(&buffer).unwrap();
+    assert!(output[0]["file"].as_str().is_some());
+    assert_eq!(output[0]["loc"], 1);
 }
 
 // ==================== STATS COMMAND TESTS ====================

--- a/cytoscnpy/tests/cross_file_dead_code_regressions_test.rs
+++ b/cytoscnpy/tests/cross_file_dead_code_regressions_test.rs
@@ -1,0 +1,196 @@
+//! Regression tests for cross-file dead-code name and import resolution.
+#![allow(clippy::unwrap_used)]
+
+use cytoscnpy::analyzer::{AnalysisResult, CytoScnPy};
+use std::path::Path;
+use tempfile::TempDir;
+
+fn project_tempdir() -> TempDir {
+    let target_dir = std::env::current_dir()
+        .unwrap()
+        .join("target")
+        .join("test-cross-file-dead-code-tmp");
+    std::fs::create_dir_all(&target_dir).unwrap();
+    tempfile::Builder::new()
+        .prefix("cross_file_dead_code_")
+        .tempdir_in(target_dir)
+        .unwrap()
+}
+
+fn write_file(path: &Path, source: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, source).unwrap();
+}
+
+fn analyze(root: &Path) -> AnalysisResult {
+    CytoScnPy::default()
+        .with_confidence(60)
+        .with_tests(false)
+        .analyze(root)
+}
+
+#[test]
+fn star_import_without_all_resolves_public_source_symbols() {
+    let dir = project_tempdir();
+    let pkg = dir.path().join("pkg");
+    write_file(&pkg.join("__init__.py"), "");
+    write_file(
+        &pkg.join("lib.py"),
+        "pub_const = 41\n\ndef used_via_star():\n    return pub_const + 1\n",
+    );
+    write_file(
+        &pkg.join("main.py"),
+        "from pkg.lib import *\n\nresult = used_via_star() + pub_const\n",
+    );
+
+    let result = analyze(dir.path());
+
+    assert!(
+        !result
+            .unused_functions
+            .iter()
+            .any(|def| def.full_name == "pkg.lib.used_via_star"),
+        "a public function used through a star import must remain live"
+    );
+    assert!(
+        !result
+            .unused_variables
+            .iter()
+            .any(|def| def.full_name == "pkg.lib.pub_const"),
+        "a public variable used through a star import must remain live"
+    );
+}
+
+#[test]
+fn public_name_fallback_propagates_through_star_import_chains() {
+    let dir = project_tempdir();
+    let pkg = dir.path().join("pkg");
+    write_file(&pkg.join("__init__.py"), "");
+    write_file(
+        &pkg.join("base.py"),
+        "def chained_function():\n    return 42\n",
+    );
+    write_file(&pkg.join("middle.py"), "from pkg.base import *\n");
+    write_file(
+        &pkg.join("main.py"),
+        "from pkg.middle import *\n\nresult = chained_function()\n",
+    );
+
+    let result = analyze(dir.path());
+
+    assert!(
+        !result
+            .unused_functions
+            .iter()
+            .any(|def| def.full_name == "pkg.base.chained_function"),
+        "public fallback bindings must propagate through consecutive star imports"
+    );
+}
+
+#[test]
+fn src_layout_uses_the_python_package_name() {
+    let dir = project_tempdir();
+    let pkg = dir.path().join("src").join("pkg");
+    write_file(&pkg.join("__init__.py"), "");
+    write_file(&pkg.join("lib.py"), "MY_CONSTANT = 42\n");
+    write_file(
+        &pkg.join("main.py"),
+        "from pkg.lib import MY_CONSTANT\n\nresult = MY_CONSTANT\n",
+    );
+
+    let result = analyze(dir.path());
+
+    assert!(
+        !result
+            .unused_variables
+            .iter()
+            .any(|def| def.simple_name == "MY_CONSTANT"),
+        "src/pkg/lib.py must be named pkg.lib so its imported constant resolves"
+    );
+    assert!(
+        !result
+            .unused_imports
+            .iter()
+            .any(|def| def.simple_name == "MY_CONSTANT"),
+        "the used import binding must not be reported unused"
+    );
+}
+
+#[test]
+fn package_name_is_stable_when_scanning_a_subdirectory() {
+    let dir = project_tempdir();
+    let pkg = dir.path().join("pkg");
+    let subpkg = pkg.join("subpkg");
+    write_file(&pkg.join("__init__.py"), "");
+    write_file(&subpkg.join("__init__.py"), "");
+    write_file(&subpkg.join("lib.py"), "PACKAGE_VALUE = 42\n");
+    write_file(
+        &subpkg.join("consumer.py"),
+        "from pkg.subpkg.lib import PACKAGE_VALUE\n\nresult = PACKAGE_VALUE\n",
+    );
+
+    let result = analyze(&subpkg);
+
+    assert!(
+        !result
+            .unused_variables
+            .iter()
+            .any(|def| def.simple_name == "PACKAGE_VALUE"),
+        "qualified names must retain pkg.subpkg when the scan starts inside the package"
+    );
+}
+
+#[test]
+fn explicit_empty_all_disables_public_name_fallback() {
+    let dir = project_tempdir();
+    write_file(
+        &dir.path().join("lib.py"),
+        "__all__ = []\n\ndef excluded_function():\n    return 42\n",
+    );
+    write_file(
+        &dir.path().join("main.py"),
+        "from lib import *\n\nresult = excluded_function()\n",
+    );
+
+    let result = analyze(dir.path());
+
+    assert!(
+        result
+            .unused_functions
+            .iter()
+            .any(|def| def.full_name == "lib.excluded_function"),
+        "an explicit empty __all__ must not fall back to public module names"
+    );
+}
+
+#[test]
+fn unused_import_does_not_keep_source_function_alive() {
+    let dir = project_tempdir();
+    write_file(
+        &dir.path().join("lib.py"),
+        "def dead_function():\n    return 42\n",
+    );
+    write_file(
+        &dir.path().join("main.py"),
+        "from lib import dead_function\n",
+    );
+
+    let result = analyze(dir.path());
+
+    assert!(
+        result
+            .unused_imports
+            .iter()
+            .any(|def| def.full_name == "main.dead_function"),
+        "the unused local import binding must be reported"
+    );
+    assert!(
+        result
+            .unused_functions
+            .iter()
+            .any(|def| def.full_name == "lib.dead_function"),
+        "an unused import must not count as a use of its source function"
+    );
+}

--- a/cytoscnpy/tests/halstead_test.rs
+++ b/cytoscnpy/tests/halstead_test.rs
@@ -12,7 +12,7 @@ fn test_halstead_simple() {
         let metrics = analyze_halstead(&ruff_python_ast::Mod::Module(m));
         // Operators: = (1)
         // Operands: x, 1 (2)
-        // n1 = 1, n2 = 2
+        // h1 = 1, h2 = 2
         // N1 = 1, N2 = 2
         assert_eq!(metrics.h1, 1);
         assert_eq!(metrics.h2, 2);
@@ -39,8 +39,8 @@ fn test_halstead_function() {
         // Distinct operands: foo, x, 1 = 3
 
         assert_eq!(metrics.h1, 3);
-        assert_eq!(metrics.h2, 4);
+        assert_eq!(metrics.h2, 3);
         assert_eq!(metrics.n1, 3);
-        assert_eq!(metrics.n2, 3);
+        assert_eq!(metrics.n2, 4);
     }
 }

--- a/cytoscnpy/tests/pr119_review_regressions_test.rs
+++ b/cytoscnpy/tests/pr119_review_regressions_test.rs
@@ -1,0 +1,181 @@
+//! Regression coverage for actionable bot feedback on merged PR #119.
+#![allow(clippy::unwrap_used)]
+
+use cytoscnpy::analyzer::AnalysisResult;
+use cytoscnpy::complexity::{analyze_complexity, calculate_module_complexity};
+use cytoscnpy::framework::FrameworkAwareVisitor;
+use cytoscnpy::halstead::analyze_halstead;
+use cytoscnpy::metrics::mi_compute;
+use cytoscnpy::raw_metrics::analyze_raw;
+use cytoscnpy::report::gitlab;
+use cytoscnpy::rules::secrets::SecretFinding;
+use cytoscnpy::utils::LineIndex;
+use std::path::{Path, PathBuf};
+
+fn visit_framework<'a>(source: &str, line_index: &'a LineIndex) -> FrameworkAwareVisitor<'a> {
+    let parsed = ruff_python_parser::parse_module(source).unwrap();
+    let module = parsed.into_syntax();
+    let mut visitor = FrameworkAwareVisitor::new(line_index);
+    for statement in &module.body {
+        visitor.visit_stmt(statement);
+    }
+    visitor
+}
+
+#[test]
+fn complexity_reports_do_not_fold_nested_definition_bodies() {
+    let source = "class Handler:\n    def run(self, value):\n        if value:\n            return 1\n        return 0\n";
+    let findings = analyze_complexity(source, Path::new("sample.py"), false);
+
+    assert!(!findings.iter().any(|finding| finding.name == "<module>"));
+    assert_eq!(
+        findings
+            .iter()
+            .find(|finding| finding.name == "Handler")
+            .unwrap()
+            .complexity,
+        1
+    );
+    assert_eq!(
+        findings
+            .iter()
+            .find(|finding| finding.name == "run")
+            .unwrap()
+            .complexity,
+        2
+    );
+    assert_eq!(calculate_module_complexity(source), Some(2));
+}
+
+#[test]
+fn raw_metrics_count_assigned_multiline_literals_and_fallback_lloc() {
+    let multiline = "value = \"\"\"first\nsecond\nthird\"\"\"\n";
+    let metrics = analyze_raw(multiline);
+    assert_eq!(metrics.multi, 3);
+
+    let invalid = "def broken(:\n    return 1\n";
+    let invalid_metrics = analyze_raw(invalid);
+    assert!(invalid_metrics.sloc > 0);
+    assert_eq!(invalid_metrics.lloc, invalid_metrics.sloc);
+}
+
+#[test]
+fn flask_add_url_rule_resolves_keyword_and_third_positional_views() {
+    let source = r#"
+from flask import Flask
+app = Flask(__name__)
+
+def keyword_view():
+    return "keyword"
+
+def positional_view():
+    return "positional"
+
+app.add_url_rule("/keyword", view_func=keyword_view)
+app.add_url_rule("/positional", "positional", positional_view)
+"#;
+    let line_index = LineIndex::new(source);
+    let visitor = visit_framework(source, &line_index);
+
+    assert!(visitor
+        .framework_references
+        .contains(&"keyword_view".to_owned()));
+    assert!(visitor
+        .framework_references
+        .contains(&"positional_view".to_owned()));
+}
+
+#[test]
+fn common_drf_base_classes_mark_dispatched_methods() {
+    let source = r"
+from rest_framework import generics, viewsets
+
+class Items(viewsets.ModelViewSet):
+    def list(self, request):
+        return []
+
+class ItemDetail(generics.GenericAPIView):
+    def get(self, request):
+        return None
+";
+    let line_index = LineIndex::new(source);
+    let visitor = visit_framework(source, &line_index);
+
+    assert!(visitor.is_framework_file);
+    assert!(visitor.framework_decorated_lines.contains(&5));
+    assert!(visitor.framework_decorated_lines.contains(&9));
+}
+
+#[test]
+fn relative_flask_blueprint_route_is_framework_provenance() {
+    let source = r#"
+from . import bp
+
+@bp.route("/items")
+def list_items():
+    return []
+"#;
+    let line_index = LineIndex::new(source);
+    let visitor = visit_framework(source, &line_index);
+
+    assert!(visitor.is_framework_file);
+    assert!(visitor.detected_frameworks.contains("flask"));
+    assert!(visitor.framework_decorated_lines.contains(&5));
+
+    let unrelated = "@bp.route('/items')\ndef list_items():\n    return []\n";
+    let unrelated_index = LineIndex::new(unrelated);
+    let unrelated_visitor = visit_framework(unrelated, &unrelated_index);
+    assert!(!unrelated_visitor.is_framework_file);
+}
+
+#[test]
+fn mi_comment_weight_uses_radians_of_comment_percentage() {
+    let score = mi_compute(10_000.0, 20, 500, 50);
+    assert!((score - 47.977_673_494_241_1).abs() < 1e-12);
+}
+
+#[test]
+fn halstead_fields_preserve_standard_distinct_and_total_semantics() {
+    let parsed = ruff_python_parser::parse_module("result = value + value + value").unwrap();
+    let module = ruff_python_ast::Mod::Module(parsed.into_syntax());
+    let metrics = analyze_halstead(&module);
+
+    assert!(metrics.n1 > metrics.h1, "N1 must be total operators");
+    assert!(metrics.n2 > metrics.h2, "N2 must be total operands");
+    assert!((metrics.vocabulary - (metrics.h1 + metrics.h2) as f64).abs() < f64::EPSILON);
+    assert!((metrics.length - (metrics.n1 + metrics.n2) as f64).abs() < f64::EPSILON);
+}
+
+#[test]
+fn gitlab_secret_fingerprints_disambiguate_same_line_findings() {
+    let mut result = AnalysisResult::default();
+    for (message, matched, confidence) in [
+        ("Hardcoded password", "abcd...wxyz", 100),
+        ("Hardcoded password variant", "1234...7890", 95),
+    ] {
+        result.secrets.push(SecretFinding {
+            message: message.to_owned(),
+            rule_id: "CSP-S001".to_owned(),
+            category: "Secrets".to_owned(),
+            file: PathBuf::from("config.py"),
+            line: 20,
+            severity: "CRITICAL".to_owned(),
+            matched_value: Some(matched.to_owned()),
+            entropy: None,
+            confidence,
+        });
+    }
+
+    let mut buffer = Vec::new();
+    gitlab::print_gitlab(&mut buffer, &result).unwrap();
+    let issues: serde_json::Value = serde_json::from_slice(&buffer).unwrap();
+    let fingerprints: Vec<&str> = issues
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|issue| issue["fingerprint"].as_str())
+        .collect();
+
+    assert_eq!(fingerprints.len(), 2);
+    assert_ne!(fingerprints[0], fingerprints[1]);
+}

--- a/cytoscnpy/tests/radon_parity_halstead_test.rs
+++ b/cytoscnpy/tests/radon_parity_halstead_test.rs
@@ -13,7 +13,7 @@ fn get_halstead_counts(code: &str) -> (usize, usize, usize, usize) {
         if let ruff_python_ast::Mod::Module(m) = ast.into_syntax() {
             let metrics = analyze_halstead(&ruff_python_ast::Mod::Module(m));
             // Returns (total_operators, total_operands, distinct_operators, distinct_operands)
-            return (metrics.h1, metrics.h2, metrics.n1, metrics.n2);
+            return (metrics.n1, metrics.n2, metrics.h1, metrics.h2);
         }
     }
     (0, 0, 0, 0)

--- a/cytoscnpy/tests/raw_metrics_test.rs
+++ b/cytoscnpy/tests/raw_metrics_test.rs
@@ -100,14 +100,14 @@ def main():
     // LOC: 12
     // Blank: 3 (1, 3, 7)
     // Comments: 1 (5)
-    // Multi: 0 (this is a data string, not a docstring)
-    // SLOC: 8 (data-string lines are code)
+    // Multi: 4 (all physical lines in the multiline data string)
+    // SLOC: 8 (non-docstring multiline literals remain code)
 
     let metrics = analyze_raw(code);
     assert_eq!(metrics.loc, 12);
     assert_eq!(metrics.blank, 3);
     assert_eq!(metrics.comments, 1);
-    assert_eq!(metrics.multi, 0);
+    assert_eq!(metrics.multi, 4);
     assert_eq!(metrics.sloc, 8);
     assert_eq!(metrics.lloc, 4);
 }

--- a/cytoscnpy/tests/real_data_test.rs
+++ b/cytoscnpy/tests/real_data_test.rs
@@ -32,12 +32,14 @@ fn test_real_data_scenarios() {
         "hidden_gem should be used"
     );
 
-    // 2. Check User.save (method) should be used via processor.py hasattr()
+    // 2. Calls inside an unreachable function must not keep methods alive.
+    // Cross-file dynamic dispatch from a reachable caller is covered separately
+    // by `complex_dynamic_test::test_hasattr_cross_file`.
     println!("Unused functions: {unused_funcs:?}");
     println!("Unused methods: {unused_methods:?}");
     assert!(
-        !unused_methods.contains(&"save".to_owned()),
-        "User.save should be used"
+        unused_methods.contains(&"save".to_owned()),
+        "User.save should be unused when its only caller is unreachable"
     );
     assert!(
         unused_methods.contains(&"delete".to_owned()),

--- a/cytoscnpy/tests/report_formats_test.rs
+++ b/cytoscnpy/tests/report_formats_test.rs
@@ -257,7 +257,9 @@ fn test_gitlab_report_coverage() {
     assert!(output.contains(r#""check_name": "CSP-Q001""#));
     assert!(output.contains(r#""fingerprint": "taint-CSP-T001-test.py-12-15-10""#));
     assert!(output.contains(r#""check_name": "CSP-T001""#));
-    assert!(output.contains(r#""fingerprint": "secret-CSP-S001-test.py-20""#));
+    assert!(
+        output.contains(r#""fingerprint": "secret-CSP-S001-test.py-20-100-Hardcoded password-"#)
+    );
     assert!(output.contains(r#""check_name": "CSP-S001""#));
     assert!(output.contains(r#""fingerprint": "parse-error-test.py-Syntax error at line 40""#));
     assert!(output.contains(r#""check_name": "ParseError""#));

--- a/cytoscnpy/tests/snapshots/output_snapshot_test__gitlab_output.snap
+++ b/cytoscnpy/tests/snapshots/output_snapshot_test__gitlab_output.snap
@@ -1,11 +1,11 @@
 ---
 source: cytoscnpy/tests/output_snapshot_test.rs
-assertion_line: 149
+assertion_line: 152
 expression: output
 ---
 [
   {
-    "check_name": "func",
+    "check_name": "UnusedFunction",
     "description": "Unused function: [MOD].unused_func ([FILE]:5)",
     "fingerprint": "unused-func-[MOD].unused_func-[FILE]-5",
     "location": {
@@ -17,7 +17,7 @@ expression: output
     "severity": "minor"
   },
   {
-    "check_name": "import",
+    "check_name": "UnusedImport",
     "description": "Unused import: [MOD].os ([FILE]:2)",
     "fingerprint": "unused-import-[MOD].os-[FILE]-2",
     "location": {
@@ -29,7 +29,7 @@ expression: output
     "severity": "info"
   },
   {
-    "check_name": "import",
+    "check_name": "UnusedImport",
     "description": "Unused import: [MOD].sys ([FILE]:3)",
     "fingerprint": "unused-import-[MOD].sys-[FILE]-3",
     "location": {
@@ -41,7 +41,7 @@ expression: output
     "severity": "info"
   },
   {
-    "check_name": "var",
+    "check_name": "UnusedVariable",
     "description": "Unused variable: [MOD].main.unused_var ([FILE]:9)",
     "fingerprint": "unused-var-[MOD].main.unused_var-[FILE]-9",
     "location": {

--- a/cytoscnpy/tests/snapshots/output_snapshot_test__json_output.snap
+++ b/cytoscnpy/tests/snapshots/output_snapshot_test__json_output.snap
@@ -1,6 +1,6 @@
 ---
 source: cytoscnpy/tests/output_snapshot_test.rs
-assertion_line: 128
+assertion_line: 131
 expression: output
 ---
 {
@@ -27,10 +27,10 @@ expression: output
     "parse_errors_count": 0,
     "quality_count": 0,
     "raw_metrics": {
-      "blank": 6,
+      "blank": 5,
       "comments": 0,
       "lloc": 9,
-      "loc": 15,
+      "loc": 14,
       "multi": 0,
       "single_comments": 0,
       "sloc": 9
@@ -50,7 +50,7 @@ expression: output
     {
       "complexity": 2.0,
       "file": "[FILE]",
-      "loc": 15,
+      "loc": 14,
       "mi": 100.0,
       "sloc": 9,
       "total_issues": 4

--- a/editors/vscode/cytoscnpy/package-lock.json
+++ b/editors/vscode/cytoscnpy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cytoscnpy",
-  "version": "1.2.26",
+  "version": "1.2.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cytoscnpy",
-      "version": "1.2.26",
+      "version": "1.2.27",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/editors/vscode/cytoscnpy/package.json
+++ b/editors/vscode/cytoscnpy/package.json
@@ -3,7 +3,7 @@
   "publisher": "djinn09",
   "displayName": "CytoScnPy",
   "description": "Python static analyzer with MCP server for GitHub Copilot. Real-time dead code detection, security scanning, and code quality metrics.",
-  "version": "1.2.26",
+  "version": "1.2.27",
   "icon": "assets/icon.png",
   "repository": {
     "type": "git",


### PR DESCRIPTION
… raw metrics

- Preserve test-referenced symbols re-exported via package __init__.py
- Resolve module names for files under regular packages (walk up __init__.py chain)
- Detect Flask blueprint routes via relative-imported blueprint objects
- Resolve add_url_rule view_func passed as keyword arg
- Support arbitrary framework base classes via FRAMEWORK_BASE_CLASSES list
- Track empty __all__ declarations separately from 'no __all__'
- Fix multi-line string/docstring accounting in raw metrics (metrics.multi)
- Make clone-pair subtree cache LRU instead of FIFO, avoid re-reading files per pair
- Include more fields in GitLab secret fingerprint to avoid false-dedup collisions